### PR TITLE
[3414203] Fixed Eslint fails in Starterkit "lint" script if there are no JS files in components.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/package.json
@@ -13,7 +13,7 @@
     "storybook-full": "export NODE_OPTIONS=--openssl-legacy-provider && export STORYBOOK_FULL=1 && npm run gulp:build && concurrently --raw=true \"npm run gulp:watch\" \"start-storybook -s .storybook/static\"\n",
     "gulp:build": "gulp",
     "gulp:watch": "gulp watch",
-    "lint": "eslint ./components ./.storybook ./webpack && stylelint 'components/**/*.scss'",
+    "lint": "eslint --no-error-on-unmatched-pattern ./components ./.storybook ./webpack && stylelint 'components/**/*.scss'",
     "lint:fix": "eslint ./components ./.storybook ./webpack --fix && stylelint 'components/**/*.scss' --fix",
     "dist": "export NODE_OPTIONS=--openssl-legacy-provider && npm run gulp:build && webpack --config ./webpack/webpack.prod.js",
     "dist:dev": "export NODE_OPTIONS=--openssl-legacy-provider && npm run gulp:build && webpack --config ./webpack/webpack.dev.js",


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3414203

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Added ESLint flag `--no-error-on-unmatched-pattern` to `civictheme_starter_kit/package.json` to suppress the message.

## Screenshots
![Screenshot 2024-01-22 at 2 27 55 PM](https://github.com/civictheme/monorepo-drupal/assets/83997348/98ade483-be01-430c-ad56-9b2f320cb3a8)
