### PR TITLE
Issue #3415747 by joshua1234511: Search for Component title / summary field is not working

### DIFF
--- a/tests/behat/features/search.feature
+++ b/tests/behat/features/search.feature
@@ -10,6 +10,7 @@ Feature: Search API
       | [TEST] Search result 1 firstuniquestring  | 1      | Summary 1 firstuniquestringsummary  |
       | [TEST] Search result 2 seconduniquestring | 1      | Summary 2 seconduniquestringsummary |
       | [TEST] Search result 3 thirduniquestring  | 1      | Summary 3 thirduniquestringsummary  |
+      | [TEST] Search result 4 forthuniquestring  | 1      | Summary 4 forthuniquestringsummary  |
 
     # Page 1, 3 searchable strings: 2 unique and 1 shared.
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Search result 1 firstuniquestring" has "civictheme_content" paragraph:
@@ -52,9 +53,28 @@ Feature: Search API
       | field_c_p_content:format | civictheme_rich_text                                                    |
       | field_c_p_background     | 0                                                                       |
 
+     # Page 4 searchable strings: Manual list.
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Search result 4 forthuniquestring" has "civictheme_manual_list" paragraph:
+      | field_c_p_title             | [TEST] Manual list title |
+      | field_c_p_list_column_count | 4                        |
+      | field_c_p_list_fill_width   | 0                        |
+    And "field_c_p_list_items" in "civictheme_manual_list" "paragraph" with "field_c_p_title" of "[TEST] Manual list title" has "civictheme_promo_card" paragraph:
+      | field_c_p_title   | Card title 1 testtestecardtitle1      |
+      | field_c_p_summary | Card summary 1  testtestecardsummary1 |
+    And "field_c_p_list_items" in "civictheme_manual_list" "paragraph" with "field_c_p_title" of "[TEST] Manual list title" has "civictheme_promo_card" paragraph:
+      | field_c_p_title   | Card title 2 testtestecardtitle2     |
+      | field_c_p_summary | Card summary 2 testtestecardsummary1 |
+    And "field_c_p_list_items" in "civictheme_manual_list" "paragraph" with "field_c_p_title" of "[TEST] Manual list title" has "civictheme_promo_card" paragraph:
+      | field_c_p_title   | Card title 3              |
+      | field_c_p_summary | testtesttestecardsummary3 |
+    And "field_c_p_list_items" in "civictheme_manual_list" "paragraph" with "field_c_p_title" of "[TEST] Manual list title" has "civictheme_promo_card" paragraph:
+      | field_c_p_title   | Card title 4              |
+      | field_c_p_summary | testtesttestecardsummary4 |
+
     And I index "civictheme_page" "[TEST] Search result 1 firstuniquestring" for search
     And I index "civictheme_page" "[TEST] Search result 2 seconduniquestring" for search
     And I index "civictheme_page" "[TEST] Search result 3 thirduniquestring" for search
+    And I index "civictheme_page" "[TEST] Search result 4 forthuniquestring" for search
 
     And I go to the homepage
     And I click "Search"
@@ -113,3 +133,20 @@ Feature: Search API
     Then I should see "[TEST] Search result 1 firstuniquestring" in the ".ct-list" element
     And I should see "[TEST] Search result 2 seconduniquestring" in the ".ct-list" element
     And I should see "[TEST] Search result 3 thirduniquestring" in the ".ct-list" element
+
+    # Search for manual list strings.
+    When I fill in "keywords" with "testtestecardtitle1"
+    And I press "Search"
+    Then I should see "[TEST] Search result 4 forthuniquestring" in the ".ct-list" element
+
+    When I fill in "keywords" with "testtestecardsummary1"
+    And I press "Search"
+    Then I should see "[TEST] Search result 4 forthuniquestring" in the ".ct-list" element
+
+    When I fill in "keywords" with "testtesttestecardsummary3"
+    And I press "Search"
+    Then I should see "[TEST] Search result 4 forthuniquestring" in the ".ct-list" element
+
+    When I fill in "keywords" with "testtesttestecardsummary4"
+    And I press "Search"
+    Then I should see "[TEST] Search result 4 forthuniquestring" in the ".ct-list" element

--- a/web/themes/contrib/civictheme/config/optional/search_api.index.civictheme_content.yml
+++ b/web/themes/contrib/civictheme/config/optional/search_api.index.civictheme_content.yml
@@ -158,6 +158,7 @@ processor_settings:
   content_access:
     weights:
       preprocess_query: -30
+  custom_value: {  }
   entity_type: {  }
   ignorecase:
     weights:
@@ -169,6 +170,10 @@ processor_settings:
       - field_c_p_content
       - field_c_p_summary
       - field_c_p_title
+      - manual_list_items_field_c_p_content
+      - manual_list_items_field_c_p_subtitle
+      - manual_list_items_field_c_p_summary
+      - manual_list_items_field_c_p_title
       - title
   language_with_fallback: {  }
   rendered_item: {  }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3415747

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Enable this processor for components fields.

## Screenshots
![FireShot Capture 003 - Test search issue - CivicTheme Source - defaultdev civictheme io](https://github.com/civictheme/monorepo-drup
![Screenshot 2024-01-23 at 11 49 42 PM](https://github.com/civictheme/monorepo-drupal/assets/83997348/edf661a1-36f3-4d58-b273-9139981d8a98)
al/assets/83997348/570ab839-72e4-41b2-8176-ebc0f6391886)

![Screenshot 2024-01-24 at 12 37 59 PM](https://github.com/civictheme/monorepo-drupal/assets/83997348/ffc03e5e-3723-4e2f-9870-3d1907897822)
