### PR TITLE
Updated containers to 24.1.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ aliases:
       DEPLOY_SSH_FINGERPRINT4: *deploy_ssh_fingerprint4
       GIT_MIRROR_SSH_FINGERPRINT: *git_mirror_ssh_fingerprint
     docker:
-      - image: drevops/ci-runner:23.12.0
+      - image: drevops/ci-runner:24.1.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -43,7 +43,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2023d-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -8,7 +8,7 @@
 #
 # @see https://hub.docker.com/r/uselagoon/php-8.2-cli-drupal/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-cli-drupal
-FROM uselagoon/php-8.2-cli-drupal:23.12.0
+FROM uselagoon/php-8.2-cli-drupal:24.1.0
 
 # Add missing variables.
 # @todo Remove once https://github.com/uselagoon/lagoon/issues/3121 is resolved.
@@ -43,7 +43,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20231125-r0 pv=1.8.5-r0 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/cli.onlytheme.dockerfile
+++ b/.docker/cli.onlytheme.dockerfile
@@ -42,7 +42,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2023d-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/cli.onlytheme.dockerfile
+++ b/.docker/cli.onlytheme.dockerfile
@@ -7,7 +7,7 @@
 #
 # @see https://hub.docker.com/r/uselagoon/php-8.2-cli-drupal/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-cli-drupal
-FROM uselagoon/php-8.2-cli-drupal:23.12.0
+FROM uselagoon/php-8.2-cli-drupal:24.1.0
 
 # Add missing variables.
 # @todo Remove once https://github.com/uselagoon/lagoon/issues/3121 is resolved.
@@ -42,7 +42,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20231125-r0 pv=1.8.5-r0 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/cli.sibling.dockerfile
+++ b/.docker/cli.sibling.dockerfile
@@ -43,7 +43,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2023d-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/cli.sibling.dockerfile
+++ b/.docker/cli.sibling.dockerfile
@@ -8,7 +8,7 @@
 #
 # @see https://hub.docker.com/r/uselagoon/php-8.2-cli-drupal/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-cli-drupal
-FROM uselagoon/php-8.2-cli-drupal:23.12.0
+FROM uselagoon/php-8.2-cli-drupal:24.1.0
 
 # Add missing variables.
 # @todo Remove once https://github.com/uselagoon/lagoon/issues/3121 is resolved.
@@ -43,7 +43,7 @@ ENV WEBROOT=${WEBROOT} \
 
 # Adding more tools.
 RUN apk update \
-    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2024a-r0 \
+    && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20231125-r0 pv=1.8.5-r0 tzdata=2024a-r0 \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 

--- a/.docker/mariadb.dockerfile
+++ b/.docker/mariadb.dockerfile
@@ -8,7 +8,7 @@
 # @see https://github.com/drevops/mariadb-drupal-data
 #
 # The ARG value will be updated with a value passed from docker-compose.yml
-ARG IMAGE=uselagoon/mariadb-drupal:23.12.0
+ARG IMAGE=uselagoon/mariadb-drupal:24.1.0
 
 # hadolint ignore=DL3006
 FROM ${IMAGE}

--- a/.docker/nginx-drupal.dockerfile
+++ b/.docker/nginx-drupal.dockerfile
@@ -13,6 +13,6 @@ FROM uselagoon/nginx-drupal:23.12.0
 ARG WEBROOT=web
 ENV WEBROOT=${WEBROOT}
 
-RUN apk add --no-cache tzdata=2023d-r0
+RUN apk add --no-cache tzdata=2024a-r0
 
 COPY --from=cli /app /app

--- a/.docker/nginx-drupal.dockerfile
+++ b/.docker/nginx-drupal.dockerfile
@@ -7,7 +7,7 @@ FROM ${CLI_IMAGE:-cli} as cli
 
 # @see https://hub.docker.com/r/uselagoon/nginx-drupal/tags?page=1
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/nginx-drupal
-FROM uselagoon/nginx-drupal:23.12.0
+FROM uselagoon/nginx-drupal:24.1.0
 
 # Webroot is used for Nginx web configuration.
 ARG WEBROOT=web

--- a/.docker/php.dockerfile
+++ b/.docker/php.dockerfile
@@ -8,7 +8,7 @@ FROM ${CLI_IMAGE:-cli} as cli
 
 # @see https://hub.docker.com/r/uselagoon/php-7.4-fpm/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-fpm
-FROM uselagoon/php-8.2-fpm:23.12.0
+FROM uselagoon/php-8.2-fpm:24.1.0
 
 RUN apk add --no-cache tzdata=2024a-r0
 

--- a/.docker/php.dockerfile
+++ b/.docker/php.dockerfile
@@ -10,6 +10,6 @@ FROM ${CLI_IMAGE:-cli} as cli
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-fpm
 FROM uselagoon/php-8.2-fpm:23.12.0
 
-RUN apk add --no-cache tzdata=2023d-r0
+RUN apk add --no-cache tzdata=2024a-r0
 
 COPY --from=cli /app /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       context: .
       dockerfile: .docker/mariadb.dockerfile
       args:
-        IMAGE: "${DREVOPS_DB_DOCKER_IMAGE:-uselagoon/mariadb-drupal:23.12.0}" # Use custom database image (if defined) or fallback to standard database image.
+        IMAGE: "${DREVOPS_DB_DOCKER_IMAGE:-uselagoon/mariadb-drupal:24.1.0}" # Use custom database image (if defined) or fallback to standard database image.
     <<: *default-user
     environment:
       <<: *default-environment

--- a/web/themes/contrib/civictheme/includes/link.inc
+++ b/web/themes/contrib/civictheme/includes/link.inc
@@ -138,7 +138,7 @@ function _civictheme_process_html_content_links_emails(string $html): string {
   }
 
   foreach ($text_nodes as $text_node) {
-    if (preg_match_all(_civictheme_process_html_content_links_get_email_regex(), $text_node->nodeValue, $matches)) {
+    if (preg_match_all(_civictheme_process_html_content_links_get_email_regex(), (string) $text_node->nodeValue, $matches)) {
       $emails = $matches[0];
       foreach ($emails as $email) {
         $replacement = $dom->createDocumentFragment();

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -90,7 +90,7 @@ function civictheme_media_get_variables(MediaInterface $media): ?array {
 
   return [
     'name' => t('@name', ['@name' => $file->label()]),
-    'ext' => pathinfo($file->getFileUri(), PATHINFO_EXTENSION) ?: '',
+    'ext' => pathinfo((string) $file->getFileUri(), PATHINFO_EXTENSION) ?: '',
     'url' => civictheme_media_get_url($media),
     // @phpstan-ignore-next-line
     'size' => DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', static fn(): TranslatableMarkup => ByteSizeMarkup::create($file->getSize()), static fn() => format_size($file->getSize())),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

After the latest upgrade local env wasn't working because of the package version change.

1. Tzdata package fix.

## Screenshots

```

 => [mariadb internal] load build context                                                                                         0.2s
 => => transferring context: 301B                                                                                                 0.0s
 => [mariadb 1/3] FROM docker.io/uselagoon/mariadb-drupal:23.12.0@sha256:3f251b7f6da4f6620a9ca4941ae46e0980f9acd68aa18c5ecbda427  0.0s
 => CACHED [mariadb 2/3] COPY ./.docker/config/mariadb/my.cnf /etc/my.cnf.d/server.cnf                                            0.0s
 => CACHED [mariadb 3/3] RUN fix-permissions /etc/my.cnf.d/                                                                       0.0s
 => [mariadb] exporting to image                                                                                                  0.0s
 => => exporting layers                                                                                                           0.0s
 => => writing image sha256:563596453c505a7a0aa92252251cf8671585f0e07e00cc50fa1ea6c1e82a81ce                                      0.0s
 => => naming to docker.io/library/monorepo-drupal-mariadb                                                                        0.0s
------
 > [cli  2/20] RUN apk update     && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2023d-r0     && ln -sf python3 /usr/bin/python     && rm -rf /var/cache/apk/*:
0.737 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
1.135 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
1.746 v3.18.6-10-g1bb71e18dfb [https://dl-cdn.alpinelinux.org/alpine/v3.18/main]
1.746 v3.18.6-9-g41de282e84d [https://dl-cdn.alpinelinux.org/alpine/v3.18/community]
1.746 OK: 19961 distinct packages available
2.065 ERROR: unable to select packages:
2.067   tzdata-2024a-r0:
2.067     breaks: world[tzdata=2023d-r0]
------
failed to solve: process "/bin/sh -c apk update     && apk add pv python3 make gcc g++ diffutils ncurses=6.4_p20230506-r0 pv=1.6.20-r1 tzdata=2023d-r0     && ln -sf python3 /usr/bin/python     && rm -rf /var/cache/apk/*" did not complete successfully: exit code: 1

```
