### PR TITLE
Issue #3415751 by joshua1234511: Fixed Duplicated checkboxes to show dependent colours on sub-theme settings.

### DIFF
--- a/web/themes/contrib/civictheme/theme-settings/civictheme.theme-settings.colors.js
+++ b/web/themes/contrib/civictheme/theme-settings/civictheme.theme-settings.colors.js
@@ -162,8 +162,8 @@
     },
     initLines: function ($source, $destination, context) {
       var self = this;
-      var name = $source.attr('name') + '-show-arrows';
-      var $checkbox = $source.siblings('[name="' + name + '"]');
+      var name = $source.attr('name').replace('-show-arrows', '') + '-show-arrows';
+      var $checkbox = $('[name="' + name + '"]');
       if (!$checkbox.length) {
         var id = 'id-' + Date.now() + Math.floor(Math.random() * 26);
         var $wrapper = $('<div class="js-show-dependants-container"><input type="checkbox" id="' + id + '" name="' + name + '"><label for="' + id + '">Show dependants</label></div>').insertBefore($source);


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3415751

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Fixed Duplicated checkboxes to show dependent colours on sub-theme settings.

## Screenshots
[screencast-localhost_8000-2024.02.16-01_41_27.webm](https://github.com/civictheme/monorepo-drupal/assets/83997348/ff2e029c-3e12-4eeb-9eef-363ebb3a86c8)
<img width="1316" alt="Screenshot 2024-02-16 at 1 41 53 AM" src="https://github.com/civictheme/monorepo-drupal/assets/83997348/e324d6ad-c138-468d-9067-00990d903b0a">
<img width="1369" alt="Screenshot 2024-02-16 at 1 41 11 AM" src="https://github.com/civictheme/monorepo-drupal/assets/83997348/f43ba6ea-5655-4a98-b9c5-21f015298f99">
