### PR TITLE
Issue #3414639 by joshua1234511, alex.skrypnyk:  Fixed banner shows page titles as "Access Denied" due to a block cache.

### DIFF
--- a/tests/behat/features/cache.render.feature
+++ b/tests/behat/features/cache.render.feature
@@ -1,0 +1,26 @@
+@p1 @civictheme @cache
+Feature: Validate page titles are not cached as Access Denied
+
+  Ensure that Page titles can be viewed correctly.
+
+  @api
+  Scenario: CivicTheme page can be viewed without cached page titles
+    Given I am logged in as a user with the "Content Author" role
+    When I visit "node/add/civictheme_page"
+    And I fill in "Title" with "[TEST] Page Title Test"
+    And I select "draft" from "edit-moderation-state-0-state"
+    And I press "Save"
+    Given I am an anonymous user
+    When I visit "civictheme_page" "[TEST] Page Title Test"
+    And I should see the text "Access Denied"
+    Given I am logged in as a user with the "Content Approver" role
+    When I visit "/admin/content/moderated"
+    Then I should see "[TEST] Page Title Test" in the "Draft" row
+    And I click "[TEST] Page Title Test"
+    And I select "published" from "edit-new-state"
+    And I press "Apply"
+    Then I save screenshot
+    Given I am an anonymous user
+    When I visit "civictheme_page" "[TEST] Page Title Test"
+    And I should see the text "[TEST] Page Title Test"
+    And I should not see the text "Access Denied"

--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -86,6 +86,10 @@ function _civictheme_preprocess_block__civictheme_banner__node(array &$variables
   $node = \Drupal::routeMatch()->getParameter('node_revision') ?: \Drupal::routeMatch()->getParameter('node');
 
   if (empty($node)) {
+    // Disable cache for the block so that it's not cached without a node for
+    // the next page views that could have a node.
+    $variables['#cache']['max-age'] = 0;
+
     return;
   }
 

--- a/web/themes/contrib/civictheme/includes/block_content.inc
+++ b/web/themes/contrib/civictheme/includes/block_content.inc
@@ -19,4 +19,14 @@ function _civictheme_preprocess_block__content(array &$variables): void {
     $variables['attributes']['class'][] = 'copyright';
     $variables['attributes']['class'][] = 'ct-text-regular';
   }
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $block = $variables['elements']['content']['#block_content'];
+
+  // If the node is not loaded, adjust the cache max-age of the
+  // banner block to -1.
+  if ($block && $block->bundle() == 'civictheme_banner' && !$node) {
+    $variables['#cache']['max-age'] = 0;
+  }
+
 }

--- a/web/themes/contrib/civictheme/includes/block_content.inc
+++ b/web/themes/contrib/civictheme/includes/block_content.inc
@@ -19,14 +19,4 @@ function _civictheme_preprocess_block__content(array &$variables): void {
     $variables['attributes']['class'][] = 'copyright';
     $variables['attributes']['class'][] = 'ct-text-regular';
   }
-
-  $node = \Drupal::routeMatch()->getParameter('node');
-  $block = $variables['elements']['content']['#block_content'];
-
-  // If the node is not loaded, adjust the cache max-age of the
-  // banner block to -1.
-  if ($block && $block->bundle() == 'civictheme_banner' && !$node) {
-    $variables['#cache']['max-age'] = 0;
-  }
-
 }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3414639

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Fixed Page titles cached as Access Denied Issue.

## Screenshots
