### PR TITLE
Issue #3415742 by joshua1234511:  Fixed Nodes within an Automated list should not reference itself.

### DIFF
--- a/tests/behat/features/paragraph.civictheme_automated_list.render.feature
+++ b/tests/behat/features/paragraph.civictheme_automated_list.render.feature
@@ -327,9 +327,9 @@ Feature: Automated list render
   @api @testmode
   Scenario: Automated list, is not self referenced
     Given "civictheme_page" content:
-      | title                                             | status | moderation_state | path/pathauto | path/alias        |
-      | Test page content in list                         | 1      | published        | 0             | /automated-link-1 |
-      | Test page with Automated list non self referenced | 1      | published        | 0             | /automated-link-2 |
+      | title                                             | status | moderation_state |
+      | Test page content in list                         | 1      | published        |
+      | Test page with Automated list non self referenced | 1      | published        |
     
     And I am an anonymous user
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list non self referenced" has "civictheme_automated_list" paragraph:

--- a/tests/behat/features/paragraph.civictheme_automated_list.render.feature
+++ b/tests/behat/features/paragraph.civictheme_automated_list.render.feature
@@ -324,18 +324,19 @@ Feature: Automated list render
     And I should not see an ".ct-group-filter__filters .ct-form-element--type" element
     And I should see an ".ct-group-filter__filters .ct-form-element--title" element
 
-  @api @testmode
+  @api
   Scenario: Automated list, is not self referenced
     Given "civictheme_page" content:
       | title                                             | status | moderation_state |
       | Test page content in list                         | 1      | published        |
       | Test page with Automated list non self referenced | 1      | published        |
-    
-    And I am an anonymous user
+
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list non self referenced" has "civictheme_automated_list" paragraph:
       | field_c_p_title           | [TEST] Automated list title |
       | field_c_p_list_limit_type | unlimited                   |
       | field_c_p_list_limit      | 0                           |
+
+    And I am an anonymous user
     When I visit "civictheme_page" "Test page with Automated list non self referenced"
     Then I should see a ".ct-list" element
     And I should see a ".ct-list.ct-theme-light" element

--- a/tests/behat/features/paragraph.civictheme_automated_list.render.feature
+++ b/tests/behat/features/paragraph.civictheme_automated_list.render.feature
@@ -323,3 +323,22 @@ Feature: Automated list render
     And I should see an ".ct-group-filter__filters .ct-form-element--topic" element
     And I should not see an ".ct-group-filter__filters .ct-form-element--type" element
     And I should see an ".ct-group-filter__filters .ct-form-element--title" element
+
+  @api @testmode
+  Scenario: Automated list, is not self referenced
+    Given "civictheme_page" content:
+      | title                                             | status | moderation_state | path/pathauto | path/alias        |
+      | Test page content in list                         | 1      | published        | 0             | /automated-link-1 |
+      | Test page with Automated list non self referenced | 1      | published        | 0             | /automated-link-2 |
+    
+    And I am an anonymous user
+    And "field_c_n_components" in "civictheme_page" "node" with "title" of "Test page with Automated list non self referenced" has "civictheme_automated_list" paragraph:
+      | field_c_p_title           | [TEST] Automated list title |
+      | field_c_p_list_limit_type | unlimited                   |
+      | field_c_p_list_limit      | 0                           |
+    When I visit "civictheme_page" "Test page with Automated list non self referenced"
+    Then I should see a ".ct-list" element
+    And I should see a ".ct-list.ct-theme-light" element
+    And the response should contain "ct-automated-list-"
+    And the ".ct-list .ct-promo-card__title__link" element should contain "Test page content in list"
+    And the ".ct-list .ct-promo-card__title__link" element should not contain "Test page with Automated list non self referenced"

--- a/web/modules/custom/civictheme_dev/config/install/views.view.civictheme_automated_list_test.yml
+++ b/web/modules/custom/civictheme_dev/config/install/views.view.civictheme_automated_list_test.yml
@@ -268,6 +268,42 @@ display:
           break_phrase: true
           depth: 0
           use_taxonomy_term_path: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: true
       filters:
         status:
           id: status

--- a/web/themes/contrib/civictheme/config/install/views.view.civictheme_automated_list.yml
+++ b/web/themes/contrib/civictheme/config/install/views.view.civictheme_automated_list.yml
@@ -283,6 +283,42 @@ display:
           break_phrase: true
           depth: 0
           use_taxonomy_term_path: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: true
       filters:
         status:
           id: status


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3415742

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Updated the view config to exclude the current node.
2. Updated tests to check for the current node's absence.

## Screenshots
![Screenshot 2024-03-07 at 3 46 06 PM](https://github.com/civictheme/monorepo-drupal/assets/83997348/27fc1b67-0e00-491a-bfdb-e590cf2960a5)
![Screenshot 2024-03-07 at 4 18 14 PM](https://github.com/civictheme/monorepo-drupal/assets/83997348/0486eb9d-4db4-4b7f-832f-1fdf580529ae)
