### PR TITLE
[CIVIC-1707] Created `Storybook` link in the secondary navigation and updated redirect.

### DIFF
--- a/web/modules/custom/civictheme_content/modules/civictheme_content_default/content/menu_link_content/hhh6ae32-3h1b-495a-8263-a08302a80a32.yml
+++ b/web/modules/custom/civictheme_content/modules/civictheme_content_default/content/menu_link_content/hhh6ae32-3h1b-495a-8263-a08302a80a32.yml
@@ -1,0 +1,38 @@
+_meta:
+  version: '1.0'
+  entity_type: menu_link_content
+  uuid: hhh6ae32-3h1b-495a-8263-a08302a80a32
+  bundle: menu_link_content
+  default_langcode: en
+  depends:
+    c9a1fe64-f6d1-4492-ac7f-6444698cfb12: node
+default:
+  enabled:
+    -
+      value: true
+  title:
+    -
+      value: 'Storybook'
+  menu_name:
+    -
+      value: civictheme-secondary-navigation
+  link:
+    -
+      uri: 'internal:/storybook'
+      title: ''
+      options: {  }
+  external:
+    -
+      value: false
+  rediscover:
+    -
+      value: false
+  weight:
+    -
+      value: -1
+  expanded:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true

--- a/web/modules/custom/civictheme_dev/civictheme_dev.post_update.php
+++ b/web/modules/custom/civictheme_dev/civictheme_dev.post_update.php
@@ -57,7 +57,7 @@ function civictheme_dev_post_update_provision_storybook_redirects(): string {
   $map = [
     [
       'src' => '/storybook',
-      'dst' => '/themes/contrib/civictheme/lib/uikit/storybook-static/index.html',
+      'dst' => '/themes/custom/civictheme_demo/storybook-static/index.html',
     ],
     [
       'src' => '/storybook-drupal',


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/CIVIC-1707

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Updated redirect in code to use themes/custom/civictheme_demo/storybook-static/index.html
2. Updated Default content profile to add a Storybook menu item before “Generated content” link in the secondary navigation in the header.

## Screenshots
![Screenshot 2024-03-13 at 8 25 11 AM](https://github.com/civictheme/monorepo-drupal/assets/83997348/f78f897a-6e9e-4476-b4e6-a2c0cb101af9)
