### PR TITLE
Issue #3432526 by joshua1234511: Promo component does not have padding when used with a sidebar.

### DIFF
--- a/tests/behat/features/paragraph.civictheme_promo.fields.feature
+++ b/tests/behat/features/paragraph.civictheme_promo.fields.feature
@@ -29,3 +29,5 @@ Feature: Promo fields
     And should see an "[name='field_c_n_components[0][subform][field_c_p_vertical_spacing]']" element
     And should see an "[name='field_c_n_components[0][subform][field_c_p_vertical_spacing]'].required" element
     And should not see an "[name='field_c_n_components[0][subform][field_c_p_vertical_spacing]'][disabled]" element
+
+    And I should see an "[name='field_c_n_components[0][subform][field_c_p_background][value]']" element

--- a/tests/behat/features/paragraph.civictheme_promo.render.feature
+++ b/tests/behat/features/paragraph.civictheme_promo.render.feature
@@ -8,7 +8,7 @@ Feature: Promo render
       | [TEST] Page Promo test 2 | 1      |
 
   @api
-  Scenario: CivicTheme page content type page can be viewed by anonymous with Promo light with vertical spacing
+  Scenario: CivicTheme page content type page can be viewed by anonymous with Promo light with vertical spacing without background
     Given I am an anonymous user
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page Promo test 1" has "civictheme_promo" paragraph:
       | field_c_p_title            | [TEST] Promo title                              |
@@ -22,6 +22,7 @@ Feature: Promo render
     And I should see an ".ct-promo" element
     And I should see an ".ct-promo.ct-theme-light" element
     And I should see an ".ct-promo.ct-vertical-spacing--both" element
+    And I should not see an ".ct-promo--with-background" element
     And I should see the text "[TEST] Promo title"
     And I should see the text "[TEST] Content text"
     And I should see an ".ct-promo__title" element
@@ -30,7 +31,7 @@ Feature: Promo render
     And the response should contain "https://example.com/link1"
 
   @api
-  Scenario: CivicTheme page content type page can be viewed by anonymous with promo dark without vertical space
+  Scenario: CivicTheme page content type page can be viewed by anonymous with promo dark without vertical space with background
     Given I am an anonymous user
     And "field_c_n_components" in "civictheme_page" "node" with "title" of "[TEST] Page Promo test 2" has "civictheme_promo" paragraph:
       | field_c_p_title            | [TEST] Promo title                              |
@@ -38,6 +39,7 @@ Feature: Promo render
       | field_c_p_content:value    | [TEST] Content text                             |
       | field_c_p_content:format   | civictheme_rich_text                            |
       | field_c_p_vertical_spacing | 0                                               |
+      | field_c_p_background       | 1                                               |
       | field_c_p_link             | 0: [TEST] link 2 - 1: https://example.com/link2 |
 
     When I visit "civictheme_page" "[TEST] Page Promo test 2"
@@ -45,6 +47,7 @@ Feature: Promo render
     And I should not see an ".ct-promo.ct-theme-light" element
     And I should see an ".ct-promo.ct-theme-dark" element
     And I should not see an ".ct-promo.ct-vertical-spacing--both" element
+    And I should see an ".ct-promo--with-background" element
     And I should see the text "[TEST] Promo title"
     And I should see the text "[TEST] Content text"
     And I should see an ".ct-promo__title" element

--- a/web/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/component.promo.inc
+++ b/web/modules/custom/cs_generated_content/generated_content/node/civictheme_page_variations/component.promo.inc
@@ -36,6 +36,21 @@ function _cs_generated_content_create_node_civictheme_page__variations__componen
 
       [
         'type' => 'promo',
+        'title' => 'Light, BG, ' . $helper::staticSentence(3),
+        'link' => $helper::staticLinkFieldValue(),
+        'theme' => $helper::civicthemeThemeLight(),
+        'background' => TRUE,
+      ],
+      [
+        'type' => 'promo',
+        'title' => 'Dark, BG, ' . $helper::staticSentence(3),
+        'link' => $helper::staticLinkFieldValue(),
+        'theme' => $helper::civicthemeThemeDark(),
+        'background' => TRUE,
+      ],
+
+      [
+        'type' => 'promo',
         'title' => 'Light, Content, Vertical spacing, ' . $helper::staticSentence(3),
         'content' => $helper::staticSentence(8),
         'link' => $helper::staticLinkFieldValue(),

--- a/web/themes/contrib/civictheme/civictheme.info.yml
+++ b/web/themes/contrib/civictheme/civictheme.info.yml
@@ -401,6 +401,7 @@ config_devel:
     - field.field.paragraph.civictheme_next_step.field_c_p_theme
     - field.field.paragraph.civictheme_next_step.field_c_p_title
     - field.field.paragraph.civictheme_next_step.field_c_p_vertical_spacing
+    - field.field.paragraph.civictheme_promo.field_c_p_background
     - field.field.paragraph.civictheme_promo.field_c_p_content
     - field.field.paragraph.civictheme_promo.field_c_p_link
     - field.field.paragraph.civictheme_promo.field_c_p_theme

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -532,3 +532,49 @@ function civictheme_post_update_convert_quote_to_content_component(array &$sandb
     },
   );
 }
+
+/**
+ * Add Background field to Promo Component.
+ */
+function civictheme_post_update_add_background_promo_component(array &$sandbox): ?string {
+  $new_field_configs = [
+    'field.field.paragraph.civictheme_promo.field_c_p_background' => 'field_config',
+  ];
+
+  $new_form_display_config = [
+    'civictheme_promo' => [
+      'field_c_p_background' => [
+        'type' => 'boolean_checkbox',
+        'weight' => 6,
+        'region' => 'content',
+        'settings' => [
+          'display_label' => TRUE,
+        ],
+        'third_party_settings' => [],
+      ],
+    ],
+  ];
+
+  return \Drupal::classResolver(CivicthemeUpdateHelper::class)->update(
+    $sandbox,
+    'paragraph',
+    ['civictheme_promo'],
+    // Start callback.
+    static function (CivicthemeUpdateHelper $helper) use ($new_field_configs): void {
+      $config_path = \Drupal::service('extension.list.theme')->getPath('civictheme') . '/config/install';
+      $helper->createConfigs($new_field_configs, $config_path);
+    },
+    // Process callback.
+    static function (CivicthemeUpdateHelper $helper, FieldableEntityInterface $entity): bool {
+      return TRUE;
+    },
+    // Finished callback.
+    static function (CivicthemeUpdateHelper $helper) use ($new_form_display_config): TranslatableMarkup {
+      foreach ($new_form_display_config as $bundle => $config) {
+        $helper->updateFormDisplayConfig('paragraph', $bundle, $config);
+      }
+
+      return new TranslatableMarkup("Added Background field to Promo Component.\n");
+    }
+  );
+}

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -565,8 +565,8 @@ function civictheme_post_update_add_background_promo_component(array &$sandbox):
       $helper->createConfigs($new_field_configs, $config_path);
     },
     // Process callback.
-    static function (CivicthemeUpdateHelper $helper, FieldableEntityInterface $entity): bool {
-      return TRUE;
+    static function (CivicthemeUpdateHelper $helper): void {
+      // Noop.
     },
     // Finished callback.
     static function (CivicthemeUpdateHelper $helper) use ($new_form_display_config): TranslatableMarkup {

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.paragraph.civictheme_promo.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.paragraph.civictheme_promo.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.civictheme_promo.field_c_p_background
     - field.field.paragraph.civictheme_promo.field_c_p_content
     - field.field.paragraph.civictheme_promo.field_c_p_link
     - field.field.paragraph.civictheme_promo.field_c_p_theme
@@ -16,6 +17,13 @@ targetEntityType: paragraph
 bundle: civictheme_promo
 mode: default
 content:
+  field_c_p_background:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_c_p_content:
     type: text_textarea
     weight: 2

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.paragraph.civictheme_promo.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.paragraph.civictheme_promo.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.civictheme_promo.field_c_p_background
     - field.field.paragraph.civictheme_promo.field_c_p_content
     - field.field.paragraph.civictheme_promo.field_c_p_link
     - field.field.paragraph.civictheme_promo.field_c_p_theme
@@ -17,6 +18,16 @@ targetEntityType: paragraph
 bundle: civictheme_promo
 mode: default
 content:
+  field_c_p_background:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
   field_c_p_content:
     type: text_default
     label: above

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_promo.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_promo.field_c_p_background.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_background
+    - paragraphs.paragraphs_type.civictheme_promo
+id: paragraph.civictheme_promo.field_c_p_background
+field_name: field_c_p_background
+entity_type: paragraph
+bundle: civictheme_promo
+label: Background
+description: 'Apply a themed background color and provide horizontal spacing to the component'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/themes/contrib/civictheme/includes/promo.inc
+++ b/web/themes/contrib/civictheme/includes/promo.inc
@@ -16,4 +16,5 @@ function civictheme_preprocess_paragraph__civictheme_promo(array &$variables): v
   _civictheme_preprocess_paragraph__paragraph_field__link($variables);
   _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
   _civictheme_preprocess_paragraph__paragraph_field__vertical_spacing($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__background($variables);
 }

--- a/web/themes/contrib/civictheme/tests/src/Functional/Update/CivicthemeUpdatePathBareTest.php
+++ b/web/themes/contrib/civictheme/tests/src/Functional/Update/CivicthemeUpdatePathBareTest.php
@@ -120,6 +120,9 @@ class CivicthemeUpdatePathBareTest extends UpdatePathTestBase {
     $this->assertSession()->pageTextContains('Processed: 0');
     $this->assertSession()->pageTextContains('Processed: 0');
     $this->assertSession()->pageTextContains('Updated: 0');
+
+    $this->assertSession()->pageTextContains('Update add_background_promo_component');
+    $this->assertSession()->pageTextContains("Added Background field to Promo Component.");
   }
 
 }

--- a/web/themes/contrib/civictheme/tests/src/Functional/Update/CivicthemeUpdatePathFilledTest.php
+++ b/web/themes/contrib/civictheme/tests/src/Functional/Update/CivicthemeUpdatePathFilledTest.php
@@ -119,6 +119,9 @@ class CivicthemeUpdatePathFilledTest extends UpdatePathTestBase {
     $this->assertSession()->pageTextContains('Processed: 93');
     $this->assertSession()->pageTextContains('Updated: 2');
     $this->assertSession()->pageTextContains('Skipped: 91');
+
+    $this->assertSession()->pageTextContains('Update add_background_promo_component');
+    $this->assertSession()->pageTextContains("Added Background field to Promo Component.");
   }
 
 }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3432526

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Added Background field to Promo Component.
2. Updated demo content.

## Screenshots
![FireShot Capture 002 - (l) Page  Component  Promo, sidebar - CivicTheme Source_ - monorepo-drupal docker amazee io](https://github.com/civictheme/monorepo-drupal/assets/83997348/c64ca06a-43ab-4777-aedf-3e7d961f2876)
