### PR TITLE
Converted argument to integer for CivicthemeColorUtility::mix()

### DIFF
--- a/web/themes/contrib/civictheme/src/Color/CivicthemeColorShadeFilter.php
+++ b/web/themes/contrib/civictheme/src/Color/CivicthemeColorShadeFilter.php
@@ -29,7 +29,7 @@ class CivicthemeColorShadeFilter extends CivicthemeColorFilterBase {
    * @SuppressWarnings(StaticAccess)
    */
   public function filter(string $color): string {
-    return CivicthemeColorUtility::mix($color, '#000', $this->arguments[0]);
+    return CivicthemeColorUtility::mix($color, '#000', (int) $this->arguments[0]);
   }
 
 }

--- a/web/themes/contrib/civictheme/src/Color/CivicthemeColorTintFilter.php
+++ b/web/themes/contrib/civictheme/src/Color/CivicthemeColorTintFilter.php
@@ -29,7 +29,7 @@ class CivicthemeColorTintFilter extends CivicthemeColorFilterBase {
    * @SuppressWarnings(StaticAccess)
    */
   public function filter(string $color): string {
-    return CivicthemeColorUtility::mix($color, '#fff', $this->arguments[0]);
+    return CivicthemeColorUtility::mix($color, '#fff', (int) $this->arguments[0]);
   }
 
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Converted argument to integer for CivicthemeColorUtility::mix()

The function expects int value as validated in test 
https://github.com/civictheme/monorepo-drupal/blob/develop/web/themes/contrib/civictheme/tests/src/Unit/CivicthemeColorUtilityUnitTest.php#L59

The error occurred due to  strict_types. https://github.com/civictheme/monorepo-drupal/blob/develop/web/themes/contrib/civictheme/src/Color/CivicthemeColorShadeFilter.php#L3


## Screenshots
