### PR TITLE
Issue #3441713 by RichardGaunt: Layout error when another theme renders a node.

### DIFF
--- a/web/themes/contrib/civictheme/templates/layout/layout--single-column-contained.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--single-column-contained.html.twig
@@ -16,11 +16,19 @@
 {% if content %}
   <div class="layout">
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
-      {% include '@base/layout/content-layout--single-column-contained.twig' with {
-        content: content.content,
-        modifier_class: modifier_class,
-        is_contained: is_contained,
-      } %}
+      {% if content %}
+        <div class="ct-layout--single-column">
+          <div class="container">
+            <div class="row">
+              {% block content %}
+                <div class="ct-layout__content col-m-12 col-xxs-12 {{ modifier_class }}">
+                  {{ content }}
+                </div>
+              {% endblock %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endif %}

--- a/web/themes/contrib/civictheme/templates/layout/layout--single-column-contained.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--single-column-contained.html.twig
@@ -16,19 +16,17 @@
 {% if content %}
   <div class="layout">
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
-      {% if content %}
-        <div class="ct-layout--single-column">
-          <div class="container">
-            <div class="row">
-              {% block content %}
-                <div class="ct-layout__content col-m-12 col-xxs-12 {{ modifier_class }}">
-                  {{ content }}
-                </div>
-              {% endblock %}
-            </div>
+      <div class="ct-layout--single-column">
+        <div class="container">
+          <div class="row">
+            {% block content %}
+              <div class="ct-layout__content col-m-12 col-xxs-12 {{ modifier_class }}">
+                {{ content }}
+              </div>
+            {% endblock %}
           </div>
         </div>
-      {% endif %}
+      </div>
     </div>
   </div>
 {% endif %}

--- a/web/themes/contrib/civictheme/templates/layout/layout--single-column.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--single-column.html.twig
@@ -16,15 +16,13 @@
 {% if content %}
   <div class="layout">
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
-      {% if content %}
-        <div class="ct-layout--single-column">
-          {% block content %}
-            <div class="ct-layout__content {{ modifier_class }}">
-              {{ content }}
-            </div>
-          {% endblock %}
-        </div>
-      {% endif %}
+      <div class="ct-layout--single-column">
+        {% block content %}
+          <div class="ct-layout__content {{ modifier_class }}">
+            {{ content }}
+          </div>
+        {% endblock %}
+      </div>
     </div>
   </div>
 {% endif %}

--- a/web/themes/contrib/civictheme/templates/layout/layout--single-column.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--single-column.html.twig
@@ -16,11 +16,15 @@
 {% if content %}
   <div class="layout">
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
-      {% include '@base/layout/content-layout--single-column.twig' with {
-        content: content.content,
-        modifier_class: modifier_class,
-        is_contained: is_contained,
-      } %}
+      {% if content %}
+        <div class="ct-layout--single-column">
+          {% block content %}
+            <div class="ct-layout__content {{ modifier_class }}">
+              {{ content }}
+            </div>
+          {% endblock %}
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Issue Link: https://www.drupal.org/project/civictheme/issues/3441713

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[CS-123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Inlined component layout template into drupal layout template:

see:
https://github.com/civictheme/uikit/blob/main/components/00-base/layout/content-layout--single-column.twig
https://github.com/civictheme/uikit/blob/main/components/00-base/layout/content-layout--single-column-contained.twig


This isn't a complete solution as it includes a ui kit component within the theme but demonstrates the fix required for the linked issue.