### PR TITLE
Added 3 column layout.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.api.php
+++ b/web/themes/contrib/civictheme/civictheme.api.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Core\Cache\Cache;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -59,4 +60,37 @@ function hook_civictheme_automated_list_preprocess_view_alter(array &$variables,
     $variables['with_background'] = TRUE;
     $variables['vertical_spacing'] = 'both';
   }
+
+  /**
+   * Allow to suppress page regions for pages with Layout Builder enabled.
+   *
+   * @param array $variables
+   *   Array of variables passed to the page template.
+   * @param array $context
+   *   Array of context data.
+   *   - node: The node object.
+   *   - layout_builder_settings_per_view_mode: An array of the layout builder
+   *     settings keyed by view mode.
+   *
+   * @SuppressWarnings(PHPMD.StaticAccess)
+   */
+  function hook_civictheme_layout_suppress_page_regions_alter(array &$variables, array $context): void {
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $variables['node'];
+    if ($node->bundle() == 'civictheme_page' && $context['layout_builder_settings_per_view_mode']['full']['enabled']) {
+      $variables['page']['sidebar_top_left'] = [];
+      $variables['page']['sidebar_bottom_left'] = [];
+      $variables['page']['sidebar_top_right'] = [];
+      $variables['page']['sidebar_bottom_right'] = [];
+
+      // Do not forget to merge the cache contexts.
+      $variables['#cache']['contexts'] = Cache::mergeContexts(
+        $variables['#cache']['contexts'] ?? [],
+        [
+          'user.roles:authenticated',
+        ]
+      );
+    }
+  }
+
 }

--- a/web/themes/contrib/civictheme/civictheme.layouts.yml
+++ b/web/themes/contrib/civictheme/civictheme.layouts.yml
@@ -1,3 +1,26 @@
+civictheme_three_columns:
+  label: 'Three columns'
+  path: templates/layout/
+  template: layout--three-columns
+  library: civictheme/layouts
+  category: 'CivicTheme Layouts'
+  default_region: content
+  icon_map:
+    - [first_above, main, second_above]
+    - [first_below, main, second_below]
+  regions:
+    sidebar_top_left:
+      label: 'Sidebar Top Left'
+    sidebar_bottom_left:
+      label: 'Sidebar Bottom Left'
+    main:
+      label: Main content
+    sidebar_top_right:
+      label: 'Sidebar Top Right'
+    sidebar_bottom_right:
+      label: 'Sidebar Bottom Right'
+
+# Deprecated and will be removed in 1.9. Switch to civictheme_three_columns.
 civictheme_one_column:
   label: 'Single column - edge to edge content'
   library: civictheme/layouts
@@ -10,6 +33,8 @@ civictheme_one_column:
   regions:
     content:
       label: Main content
+
+# Deprecated and will be removed in 1.9. Switch to civictheme_three_columns.
 civictheme_one_column_contained:
   label: 'Single column - contained content'
   library: civictheme/layouts

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
@@ -30,7 +30,7 @@ third_party_settings:
     allow_custom: false
     sections:
       -
-        layout_id: civictheme_one_column_contained
+        layout_id: civictheme_three_columns
         layout_settings:
           label: Main
           context_mapping: {  }

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_event.default.yml
@@ -35,9 +35,24 @@ third_party_settings:
           label: Main
           context_mapping: {  }
         components:
+          93c254ec-abeb-461a-b464-5247fd0083da:
+            uuid: 93c254ec-abeb-461a-b464-5247fd0083da
+            region: main
+            configuration:
+              id: 'extra_field_block:node:civictheme_event:content_moderation_control'
+              label: 'Moderation control'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                settings: {  }
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
           693c2dc9-0290-4122-842b-3f1b9cd69380:
             uuid: 693c2dc9-0290-4122-842b-3f1b9cd69380
-            region: content
+            region: main
             configuration:
               id: 'field_block:node:civictheme_event:field_c_n_date_range'
               label: Date
@@ -54,11 +69,11 @@ third_party_settings:
                   format_type: medium
                   separator: '-'
                 third_party_settings: {  }
-            weight: 0
+            weight: 1
             additional: {  }
           2c1b19b3-bdd8-4b90-b5ef-ddcc0026bee4:
             uuid: 2c1b19b3-bdd8-4b90-b5ef-ddcc0026bee4
-            region: content
+            region: main
             configuration:
               id: 'field_block:node:civictheme_event:field_c_n_body'
               label: Body
@@ -72,11 +87,11 @@ third_party_settings:
                 label: hidden
                 settings: {  }
                 third_party_settings: {  }
-            weight: 1
+            weight: 2
             additional: {  }
           06e90499-3555-4df7-b29e-89198edfd431:
             uuid: 06e90499-3555-4df7-b29e-89198edfd431
-            region: content
+            region: main
             configuration:
               id: 'field_block:node:civictheme_event:field_c_n_location'
               label: Locations
@@ -91,21 +106,26 @@ third_party_settings:
                 settings:
                   view_mode: default
                 third_party_settings: {  }
-            weight: 2
+            weight: 3
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
       allowed_layouts: {  }
-      restricted_categories: {  }
       denylisted_blocks: {  }
       allowlisted_blocks: {  }
+      restricted_categories: {  }
 id: node.civictheme_event.default
 targetEntityType: node
 bundle: civictheme_event
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_c_n_body:
     type: text_default
     label: above

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
@@ -38,14 +38,14 @@ third_party_settings:
     allow_custom: false
     sections:
       -
-        layout_id: civictheme_one_column
+        layout_id: civictheme_three_columns
         layout_settings:
-          label: 'CivicTheme Single Column'
+          label: 'CivicTheme Three Columns'
           context_mapping: {  }
         components:
-          fe1eb2ca-740e-4c33-b576-503ba383f7bc:
-            uuid: fe1eb2ca-740e-4c33-b576-503ba383f7bc
-            region: content
+          e1164245-8b1a-4a3f-8b30-30b00be44144:
+            uuid: e1164245-8b1a-4a3f-8b30-30b00be44144
+            region: main
             configuration:
               id: 'field_block:node:civictheme_page:field_c_n_components'
               label: Components
@@ -84,7 +84,9 @@ third_party_settings:
     allowed_block_categories: {  }
     entity_view_mode_restriction:
       allowed_layouts:
+        - civictheme_three_columns
         - civictheme_one_column
+        - civictheme_one_column_contained
       denylisted_blocks: {  }
       allowlisted_blocks: {  }
       restricted_categories: {  }

--- a/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_view_display.node.civictheme_page.default.yml
@@ -43,6 +43,21 @@ third_party_settings:
           label: 'CivicTheme Three Columns'
           context_mapping: {  }
         components:
+          5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0:
+            uuid: 5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0
+            region: main
+            configuration:
+              id: 'extra_field_block:node:civictheme_page:content_moderation_control'
+              label: 'Moderation control'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                settings: {  }
+                third_party_settings: {  }
+            weight: 1
+            additional: {  }
           e1164245-8b1a-4a3f-8b30-30b00be44144:
             uuid: e1164245-8b1a-4a3f-8b30-30b00be44144
             region: main
@@ -60,11 +75,11 @@ third_party_settings:
                 settings:
                   view_mode: default
                 third_party_settings: {  }
-            weight: 0
+            weight: 2
             additional: {  }
           c1f9f850-f470-4069-8711-9c7edaffde7e:
             uuid: c1f9f850-f470-4069-8711-9c7edaffde7e
-            region: content
+            region: main
             configuration:
               id: 'field_block:node:civictheme_page:field_c_n_custom_last_updated'
               label_display: '0'
@@ -77,7 +92,7 @@ third_party_settings:
                   timezone_override: ''
                   format_type: medium
                 third_party_settings: {  }
-            weight: 1
+            weight: 3
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
@@ -95,6 +110,11 @@ targetEntityType: node
 bundle: civictheme_page
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_c_n_banner_hide_breadcrumb:
     type: boolean
     label: above

--- a/web/themes/contrib/civictheme/includes/node.inc
+++ b/web/themes/contrib/civictheme/includes/node.inc
@@ -105,28 +105,6 @@ function _civictheme_preprocess_node__civictheme_alert__full(array &$variables):
 }
 
 /**
- * Generic page pre-process for all view mode of nodes.
- */
-function _civictheme_preprocess_page__node(array &$variables): void {
-  /** @var \Drupal\node\Entity\Node $node */
-  $node = civictheme_load_node_or_revision($variables);
-
-  // @phpstan-ignore-next-line
-  if (!$node) {
-    return;
-  }
-
-  // Layout determines whether a node is contained and what it's layout is.
-  $variables['page']['content_contained'] = FALSE;
-  $variables['page']['is_contained'] = FALSE;
-
-  $variables['vertical_spacing'] = civictheme_get_field_value($node, 'field_c_n_vertical_spacing');
-
-  // @todo Add support for hiding of the right sidebar.
-  $variables['hide_sidebar_left'] = civictheme_get_field_value($node, 'field_c_n_hide_sidebar') ?? FALSE;
-}
-
-/**
  * Determine last updated date for a page.
  */
 function _civictheme_node_get_updated_date(NodeInterface $node, string $format = 'civictheme_short_date'): ?string {

--- a/web/themes/contrib/civictheme/includes/page.inc
+++ b/web/themes/contrib/civictheme/includes/page.inc
@@ -25,3 +25,34 @@ function _civictheme_preprocess_page(array &$variables): void {
   $variables['page']['is_contained'] = $variables['page']['content_contained'] ?? TRUE;
   $variables['page']['is_contained'] = $variables['page']['is_contained'] ?? TRUE;
 }
+
+/**
+ * Generic page pre-process for all view modes of a node.
+ */
+function _civictheme_preprocess_page__node(array &$variables): void {
+  /** @var \Drupal\node\Entity\Node $node */
+  $node = civictheme_load_node_or_revision($variables);
+
+  // @phpstan-ignore-next-line
+  if (!$node) {
+    return;
+  }
+
+  // Layout determines whether a node is contained and what it's layout is.
+  $variables['page']['content_contained'] = FALSE;
+  $variables['page']['is_contained'] = FALSE;
+
+  $variables['vertical_spacing'] = civictheme_get_field_value($node, 'field_c_n_vertical_spacing');
+
+  // @todo Add support for hiding of the right sidebar.
+  $variables['hide_sidebar_left'] = civictheme_get_field_value($node, 'field_c_n_hide_sidebar') ?? FALSE;
+
+  if (civictheme_is_layout_builder_enabled($node)) {
+    // @todo Add more conditional logic on when to suppress the sidebars.
+    $variables['page']['sidebar_top_left'] = [];
+    $variables['page']['sidebar_bottom_left'] = [];
+    $variables['page']['sidebar_top_right'] = [];
+    $variables['page']['sidebar_bottom_right'] = [];
+  }
+}
+

--- a/web/themes/contrib/civictheme/includes/page.inc
+++ b/web/themes/contrib/civictheme/includes/page.inc
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Core\Cache\Cache;
 
 /**
  * Generic page pre-processing.
@@ -28,6 +29,8 @@ function _civictheme_preprocess_page(array &$variables): void {
 
 /**
  * Generic page pre-process for all view modes of a node.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function _civictheme_preprocess_page__node(array &$variables): void {
   /** @var \Drupal\node\Entity\Node $node */
@@ -44,15 +47,29 @@ function _civictheme_preprocess_page__node(array &$variables): void {
 
   $variables['vertical_spacing'] = civictheme_get_field_value($node, 'field_c_n_vertical_spacing');
 
-  // @todo Add support for hiding of the right sidebar.
+  // @todo Add support for hiding of the right sidebar through a node field.
   $variables['hide_sidebar_left'] = civictheme_get_field_value($node, 'field_c_n_hide_sidebar') ?? FALSE;
 
-  if (civictheme_is_layout_builder_enabled($node)) {
-    // @todo Add more conditional logic on when to suppress the sidebars.
-    $variables['page']['sidebar_top_left'] = [];
-    $variables['page']['sidebar_bottom_left'] = [];
-    $variables['page']['sidebar_top_right'] = [];
-    $variables['page']['sidebar_bottom_right'] = [];
+  $layout_builder_settings_per_view_mode = civictheme_get_layout_builder_settings_per_view_mode($node->getEntityTypeId(), $node->bundle());
+  if (!empty($layout_builder_settings_per_view_mode)) {
+    $variables['#cache']['contexts'] = Cache::mergeContexts(
+      $variables['#cache']['contexts'] ?? [],
+      $node->getCacheContexts(),
+      [
+        'url.query_args',
+        'url.path',
+      ]
+    );
+
+    $context = [
+      'node' => $node,
+      'layout_builder_settings_per_view_mode' => $layout_builder_settings_per_view_mode,
+    ];
+
+    // Allow to suppress sidebars. Note that implementors should ensure that
+    // the cacheability metadata is set correctly.
+    \Drupal::moduleHandler()->alter('civictheme_layout_suppress_page_regions', $variables, $context);
+    \Drupal::service('theme.manager')->alter('civictheme_layout_suppress_page_regions', $variables, $context);
   }
 }
 

--- a/web/themes/contrib/civictheme/includes/primary_navigation.inc
+++ b/web/themes/contrib/civictheme/includes/primary_navigation.inc
@@ -20,16 +20,20 @@ function civictheme_preprocess_block__menu_block__civictheme_primary_navigation(
   $variables['items'] = $variables['content']['#items'] ?? [];
   $variables['title'] = $variables['configuration']['label_display'] ? $variables['configuration']['label'] : '';
 
-  $block = Block::load($variables['elements']['#id']);
-  $region = $block->getRegion();
+  if (!empty($variables['elements']['#id'])) {
+    $block = Block::load($variables['elements']['#id']);
+    if ($block) {
+      $region = $block->getRegion();
 
-  if (str_starts_with($region, 'header')) {
-    $variables['modifier_class'] = 'ct-flex-justify-content-end';
-  }
+      if (str_starts_with($region, 'header')) {
+        $variables['modifier_class'] = 'ct-flex-justify-content-end';
+      }
 
-  if (str_starts_with($region, 'sidebar')) {
-    $variables['in_sidebar'] = TRUE;
-    $expand_all_items = $variables['configuration']['expand_all_items'] ?? FALSE;
+      if (str_starts_with($region, 'sidebar')) {
+        $variables['in_sidebar'] = TRUE;
+        $expand_all_items = $variables['configuration']['expand_all_items'] ?? FALSE;
+      }
+    }
   }
 
   _civictheme_preprocess_menu_items($variables['items'], $expand_all_items ?? FALSE);

--- a/web/themes/contrib/civictheme/includes/secondary_navigation.inc
+++ b/web/themes/contrib/civictheme/includes/secondary_navigation.inc
@@ -20,16 +20,20 @@ function civictheme_preprocess_block__menu_block__civictheme_secondary_navigatio
   $variables['items'] = $variables['content']['#items'] ?? [];
   $variables['title'] = $variables['configuration']['label_display'] ? $variables['configuration']['label'] : '';
 
-  $block = Block::load($variables['elements']['#id']);
-  $region = $block->getRegion();
+  if (!empty($variables['elements']['#id'])) {
+    $block = Block::load($variables['elements']['#id']);
+    if ($block) {
+      $region = $block->getRegion();
 
-  if (str_starts_with($region, 'header')) {
-    $variables['modifier_class'] = 'ct-flex-justify-content-end';
-  }
+      if (str_starts_with($region, 'header')) {
+        $variables['modifier_class'] = 'ct-flex-justify-content-end';
+      }
 
-  if (str_starts_with($region, 'sidebar')) {
-    $variables['in_sidebar'] = TRUE;
-    $expand_all_items = $variables['configuration']['expand_all_items'] ?? FALSE;
+      if (str_starts_with($region, 'sidebar')) {
+        $variables['in_sidebar'] = TRUE;
+        $expand_all_items = $variables['configuration']['expand_all_items'] ?? FALSE;
+      }
+    }
   }
 
   _civictheme_preprocess_menu_items($variables['items'], $expand_all_items ?? FALSE);

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -77,6 +77,8 @@ function civictheme_load_node_or_revision(array $variables): ?NodeInterface {
  *
  * @return bool
  *   TRUE if the Layout Builder is enabled for the node, FALSE otherwise.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function civictheme_is_layout_builder_enabled(NodeInterface $node, $view_mode = 'default') {
   $entity_type = $node->getEntityTypeId();

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -68,29 +68,43 @@ function civictheme_load_node_or_revision(array $variables): ?NodeInterface {
 }
 
 /**
- * Check if the Layout Builder is enabled for a node.
+ * Get Layout Builder settings for all view modes of an entity.
  *
- * @param \Drupal\node\NodeInterface $node
- *   The node to check.
- * @param string $view_mode
- *   (optional) The view mode to check. Defaults to 'default'.
+ * @param string $entity_type_id
+ *   Entity type ID.
+ * @param string $bundle
+ *   Bundle name.
+ * @param bool $only_enabled
+ *   (optional) Whether to return settings only for when the Layout Builder
+ *   is enabled for the view mode. Defaults to TRUE.
  *
- * @return bool
- *   TRUE if the Layout Builder is enabled for the node, FALSE otherwise.
+ * @return array<string, mixed>
+ *   An array of Layout Builder settings keyed by view mode.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  */
-function civictheme_is_layout_builder_enabled(NodeInterface $node, $view_mode = 'default') {
-  $entity_type = $node->getEntityTypeId();
-  $bundle = $node->bundle();
+function civictheme_get_layout_builder_settings_per_view_mode(string $entity_type_id, string $bundle, $only_enabled = TRUE): array {
+  $settings_per_mode = [];
 
-  $view_display = EntityViewDisplay::load("{$entity_type}.{$bundle}.{$view_mode}");
+  /** @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository */
+  $entity_display_repository = \Drupal::service('entity_display.repository');
+  $view_modes = array_keys($entity_display_repository->getViewModes($entity_type_id));
+  array_unshift($view_modes, 'default');
 
-  if ($view_display) {
-    return $view_display->getThirdPartySetting('layout_builder', 'enabled', FALSE);
+  foreach ($view_modes as $view_mode) {
+    $view_display = EntityViewDisplay::load("$entity_type_id.$bundle.$view_mode");
+    if ($view_display) {
+      $lb_settings = $view_display->getThirdPartySettings('layout_builder');
+      if ($only_enabled && empty($lb_settings['enabled'])) {
+        continue;
+      }
+
+      $settings_per_mode[$view_mode] = $lb_settings;
+    }
   }
 
-  return FALSE;
+  return $settings_per_mode;
 }
 
 /**

--- a/web/themes/contrib/civictheme/includes/utilities.inc
+++ b/web/themes/contrib/civictheme/includes/utilities.inc
@@ -12,13 +12,12 @@ declare(strict_types=1);
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\civictheme\CivicthemeConfigManager;
 use Drupal\civictheme\CivicthemeConstants;
-use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\StringTranslation\ByteSizeMarkup;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
@@ -66,6 +65,30 @@ function civictheme_load_node_or_revision(array $variables): ?NodeInterface {
   }
 
   return $node;
+}
+
+/**
+ * Check if the Layout Builder is enabled for a node.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node to check.
+ * @param string $view_mode
+ *   (optional) The view mode to check. Defaults to 'default'.
+ *
+ * @return bool
+ *   TRUE if the Layout Builder is enabled for the node, FALSE otherwise.
+ */
+function civictheme_is_layout_builder_enabled(NodeInterface $node, $view_mode = 'default') {
+  $entity_type = $node->getEntityTypeId();
+  $bundle = $node->bundle();
+
+  $view_display = EntityViewDisplay::load("{$entity_type}.{$bundle}.{$view_mode}");
+
+  if ($view_display) {
+    return $view_display->getThirdPartySetting('layout_builder', 'enabled', FALSE);
+  }
+
+  return FALSE;
 }
 
 /**
@@ -310,6 +333,7 @@ function civictheme_format_datetime_iso(int|string|DrupalDateTime $datetime): st
  */
 function civictheme_format_date(string $format_or_type, int|string|DrupalDateTime $datetime): string {
   @trigger_error('civictheme_format_date() is deprecated in civictheme:1.7.0 and is removed from civictheme:1.8.0. Use civictheme_format_datetime() instead. See https://www.drupal.org/project/civictheme/issues/3412647', E_USER_DEPRECATED);
+
   return civictheme_format_datetime($datetime, $format_or_type);
 }
 

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -2296,7 +2296,7 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.7.6",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#abf528e9229ebd4130f70f0e75e772222998e238",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#496354fbab52b5e1803aff8d9519ac43cafcafc6",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -32367,7 +32367,7 @@
       "dev": true
     },
     "@civictheme/uikit": {
-      "version": "git+ssh://git@github.com/civictheme/uikit.git#abf528e9229ebd4130f70f0e75e772222998e238",
+      "version": "git+ssh://git@github.com/civictheme/uikit.git#496354fbab52b5e1803aff8d9519ac43cafcafc6",
       "from": "@civictheme/uikit@civictheme/uikit.git#main",
       "requires": {
         "@popperjs/core": "^2.11.8",

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -1,0 +1,104 @@
+{#
+/**
+ * @file
+ * Layout component.
+ *
+ * Variables:
+ * - content_top: Content top slot.
+ * - sidebar_top_left: Top left sidebar slot.
+ * - sidebar_top_left_attributes: Top left sidebar attributes.
+ * - sidebar_top_right: Top right sidebar slot.
+ * - sidebar_top_right_attributes: Top right sidebar attributes.
+ * - content: Content slot.
+ * - content_attributes: Content attributes.
+ * - sidebar_bottom_left: Bottom left sidebar slot.
+ * - sidebar_bottom_left_attributes: Bottom left sidebar attributes.
+ * - sidebar_bottom_right: Bottom right sidebar slot.
+ * - sidebar_bottom_right_attributes: Bottom right sidebar attributes.
+ * - content_bottom: Content bottom slot.
+ * - hide_sidebar_left: Whether to force hide the left sidebar.
+ * - hide_sidebar_right: Whether to force hide the right sidebar.
+ * - is_contained: Whether the page is to be contained.
+ * - vertical_spacing: [string] With top, bottom or both vertical spaces.
+ * - attributes: [string] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ */
+#}
+
+{% set has_sidebar_left = (content.sidebar_top_left is not empty or content.sidebar_bottom_left is not empty) and not hide_sidebar_left|default(false) %}
+{% set has_sidebar_right = (content.sidebar_top_right is not empty or content.sidebar_bottom_right is not empty) and not hide_sidebar_right|default(false) %}
+
+{% set is_contained = is_contained|default(true) %}
+{% set is_contained = is_contained or has_sidebar_left or has_sidebar_right %}
+
+{% set vertical_spacing = has_sidebar_left or has_sidebar_right ? 'top' : vertical_spacing %}
+
+{% set no_sidebar_left_class = hide_sidebar_left ? 'ct-layout--no-sidebar-left' : '' %}
+{% set no_sidebar_right_class = hide_sidebar_right ? 'ct-layout--no-sidebar-right' : '' %}
+{% set no_tl_class = content.sidebar_top_left is empty or hide_sidebar_left ? 'ct-layout--no-top-left' : '' %}
+{% set no_tr_class = content.sidebar_top_right is empty or hide_sidebar_right ? 'ct-layout--no-top-right' : '' %}
+{% set no_bl_class = content.sidebar_bottom_left is empty or hide_sidebar_left ? 'ct-layout--no-bottom-left' : '' %}
+{% set no_br_class = content.sidebar_bottom_right is empty or hide_sidebar_right ? 'ct-layout--no-bottom-right' : '' %}
+{% set is_contained_class = is_contained ? 'container' : 'container-fluid' %}
+{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing--%s'|format(vertical_spacing) : '' %}
+
+{% set modifier_class = '%s %s %s %s %s %s %s %s'|format(no_sidebar_left_class, no_sidebar_right_class, no_tl_class, no_tr_class, no_bl_class, no_br_class, vertical_spacing_class, modifier_class|default('')) %}
+{% set modifier_class = modifier_class|trim %}
+
+{% if content %}
+  <main class="ct-layout {{ modifier_class }}" role="main" {% if attributes is not empty %}{{ attributes|raw }}{% endif %}>
+    {% block content_top %}
+      {% if content_top is not empty %}
+        {{ content_top }}
+      {% endif %}
+    {% endblock %}
+
+    <div class="ct-layout__inner {{ is_contained_class }}">
+      {% if content.main is not empty %}
+        {% block content %}
+          <section class="ct-layout__main" {% if content_attributes is not empty %}{{ content_attributes|raw }}{% endif %}>
+            {{ content.main }}
+          </section>
+        {% endblock %}
+      {% endif %}
+
+      {% if content.sidebar_top_left is not empty and has_sidebar_left %}
+        {% block sidebar_top_left %}
+          <aside class="ct-layout__sidebar_top_left" {% if content.sidebar_top_left_attributes is not empty %}{{ content.sidebar_top_left_attributes|raw }}{% endif %}>
+            {{ content.sidebar_top_left }}
+          </aside>
+        {% endblock %}
+      {% endif %}
+
+      {% if content.sidebar_top_right is not empty and has_sidebar_right %}
+        {% block sidebar_top_right %}
+          <aside class="ct-layout__sidebar_top_right" {% if content.sidebar_top_right_attributes is not empty %}{{ content.sidebar_top_right_attributes|raw }}{% endif %}>
+            {{ content.sidebar_top_right }}
+          </aside>
+        {% endblock %}
+      {% endif %}
+
+      {% if content.sidebar_bottom_left is not empty and has_sidebar_left %}
+        {% block sidebar_bottom_left %}
+          <aside class="ct-layout__sidebar_bottom_left" {% if content.sidebar_bottom_left_attributes is not empty %}{{ content.sidebar_bottom_left_attributes|raw }}{% endif %}>
+            {{ content.sidebar_bottom_left }}
+          </aside>
+        {% endblock %}
+      {% endif %}
+
+      {% if content.sidebar_bottom_right is not empty and has_sidebar_right %}
+        {% block sidebar_bottom_right %}
+          <aside class="ct-layout__sidebar_bottom_right" {% if content.sidebar_bottom_right_attributes is not empty %}{{ content.sidebar_bottom_right_attributes|raw }}{% endif %}>
+            {{ content.sidebar_bottom_right }}
+          </aside>
+        {% endblock %}
+      {% endif %}
+    </div>
+
+    {% block content_bottom %}
+      {% if content_bottom is not empty %}
+        {{ content_bottom }}
+      {% endif %}
+    {% endblock %}
+  </main>
+{% endif %}


### PR DESCRIPTION
Chnaged:

- Added a 3col layout which is a copy of the `Layout` component. We cannot have components Twig-`@included` into layouts because layouts may be accessed from another theme (i know, weird).
- Added a hook that allows the consumer theme to decide what to do with the "conflicting" regions (see image below).
- Fixed the location of the content moderation form to sit above the page.

<img width="427" alt="Cursor_and_Edit_layout_for_Page_content_items___CivicTheme_Source" src="https://github.com/civictheme/monorepo-drupal/assets/378794/e7ef3232-5f07-4c19-b99e-47ed69d87fa3">

