### PR TITLE
Issue #3426551 by naveenvalecha, tanashin-kishimoto, alex.skrypnyk: Empty Drupal message when there are exceptions thrown.

### DIFF
--- a/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
+++ b/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
@@ -7,7 +7,8 @@
 {% for type, messages in message_list %}
   {% for message in messages %}
     {% include '@organisms/message/message.twig' with {
-      title: message,
+      title: status_headings[type] ? status_headings[type] : type|capitalize,
+      description: message,
       type: type == 'status' ? 'information' : type,
     } only %}
   {% endfor %}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3426551