### PR TITLE
Issue #3457993 by alex.skrypnyk: Provisioning script does not re-use existing block UUIDs'.

### DIFF
--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -449,6 +449,7 @@ function civictheme_provision_place_block(string $label, string $region, string 
   // Remove block if it already exists.
   $block = Block::load($values['id']);
   if ($block !== NULL) {
+    $values['uuid'] = $block->uuid();
     $block->delete();
   }
 


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3457993