### PR TITLE
Fix for Lagoon CLI 3.0.

### DIFF
--- a/scripts/drevops/deploy-lagoon.sh
+++ b/scripts/drevops/deploy-lagoon.sh
@@ -167,8 +167,7 @@ else
       fi
 
       note "Redeploying environment: project ${LAGOON_PROJECT}, PR: ${DREVOPS_DEPLOY_PR}."
-      lagoon --force --skip-update-check -i "${DREVOPS_DEPLOY_SSH_FILE}" -l "${DREVOPS_DEPLOY_LAGOON_INSTANCE}" deploy pullrequest -p "${LAGOON_PROJECT}" -n "${DREVOPS_DEPLOY_PR}" --baseBranchName "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
-
+      lagoon deploy pullrequest --ssh-key "${DREVOPS_DEPLOY_SSH_FILE}" --lagoon "${DREVOPS_DEPLOY_LAGOON_INSTANCE}" --project "${LAGOON_PROJECT}" --number "${DREVOPS_DEPLOY_PR}" --base-branch-name "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" --base-branch-ref "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" --head-branch-name "${DREVOPS_DEPLOY_BRANCH}" --head-branch-ref "${DREVOPS_DEPLOY_PR_HEAD}" --title "${deploy_pr_full}"
       if [ "${DREVOPS_DEPLOY_ACTION:-}" = "deploy_override_db" ]; then
         note "Waiting for deployment to be queued."
         sleep 10
@@ -183,7 +182,7 @@ else
     else
       # If PR deployments are not configured in Lagoon - it will filter it out and will not deploy.
       note "Deploying environment: project ${LAGOON_PROJECT}, PR: ${DREVOPS_DEPLOY_PR}."
-      lagoon --force --skip-update-check -i "${DREVOPS_DEPLOY_SSH_FILE}" -l "${DREVOPS_DEPLOY_LAGOON_INSTANCE}" deploy pullrequest -p "${LAGOON_PROJECT}" -n "${DREVOPS_DEPLOY_PR}" --baseBranchName "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -R "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" -H "${DREVOPS_DEPLOY_BRANCH}" -M "${DREVOPS_DEPLOY_PR_HEAD}" -t "${deploy_pr_full}"
+      lagoon deploy pullrequest --ssh-key "${DREVOPS_DEPLOY_SSH_FILE}" --lagoon "${DREVOPS_DEPLOY_LAGOON_INSTANCE}" --project "${LAGOON_PROJECT}" --number "${DREVOPS_DEPLOY_PR}" --base-branch-name "${DREVOPS_DEPLOY_PR_BASE_BRANCH}" --base-branch-ref "origin/${DREVOPS_DEPLOY_PR_BASE_BRANCH}" --head-branch-name "${DREVOPS_DEPLOY_BRANCH}" --head-branch-ref "${DREVOPS_DEPLOY_PR_HEAD}" --title "${deploy_pr_full}"
     fi
 
   # Deploy branch.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Updated deploy script for lagoon 3.0 CLI fix
https://github.com/drevops/scaffold/commit/f0bbe9e526e14e25b9b1d15bd13b937bb050cdea

Issue identified and diagnosed by Josh: https://app.circleci.com/pipelines/github/civictheme/monorepo-drupal/7730/workflows/f689c4d3-dc7d-4d43-bbfc-8792a9532784/jobs/25677?invite=true#step-105-994_37

Note for mapping short to long name parameters
```
Usage:
  lagoon deploy pullrequest [flags]

Aliases:
  pullrequest, r

Flags:
  -N, --base-branch-name string   Pullrequest base branch name
  -R, --base-branch-ref string    Pullrequest base branch reference hash
      --buildvar stringArray      Add one or more build variables to deployment (--buildvar KEY1=VALUE1 [--buildvar KEY2=VALUE2])
  -H, --head-branch-name string   Pullrequest head branch name
  -M, --head-branch-ref string    Pullrequest head branch reference hash
  -h, --help                      help for pullrequest
  -n, --number uint               Pullrequest number
      --returndata                Returns the build name instead of success text
  -t, --title string              Pullrequest title

Global Flags:
      --config-file string                Path to the config file to use (must be *.yml or *.yaml)
      --debug                             Enable debugging output (if supported)
  -e, --environment string                Specify an environment to use
      --force                             Force yes on prompts (if supported)
  -l, --lagoon string                     The Lagoon instance to interact with
      --no-header                         No header on table (if supported)
      --output-csv                        Output as CSV (if supported)
      --output-json                       Output as JSON (if supported)
      --pretty                            Make JSON pretty (if supported)
  -p, --project string                    Specify a project to use
      --skip-update-check                 Skip checking for updates
  -i, --ssh-key string                    Specify path to a specific SSH key to use for lagoon authentication
      --ssh-publickey string              Specify path to a specific SSH public key to use for lagoon authentication using ssh-agent.
                                          This will override any public key identities defined in configuration
      --strict-host-key-checking string   Similar to SSH StrictHostKeyChecking (accept-new, no, ignore) (default "accept-new")
  -v, --verbose                           Enable verbose output to stderr (if supported)
```


## Screenshots
