### PR TITLE
Issue #3476600: Adding a layout setting for controlling space around the layout.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.theme
+++ b/web/themes/contrib/civictheme/civictheme.theme
@@ -27,6 +27,7 @@ require_once __DIR__ . '/includes/iframe.inc';
 require_once __DIR__ . '/includes/image.inc';
 require_once __DIR__ . '/includes/link.inc';
 require_once __DIR__ . '/includes/automated_list.inc';
+require_once __DIR__ . '/includes/layout.inc';
 require_once __DIR__ . '/includes/local_tasks.inc';
 require_once __DIR__ . '/includes/libraries.inc';
 require_once __DIR__ . '/includes/map.inc';

--- a/web/themes/contrib/civictheme/includes/layout.inc
+++ b/web/themes/contrib/civictheme/includes/layout.inc
@@ -12,5 +12,5 @@ declare(strict_types=1);
  */
 function civictheme_preprocess_layout__three_columns(array &$variables): void {
   $variables['is_contained'] = $variables['settings']['is_contained'] ?? FALSE;
-  $variables['vertical_spacing'] = $variables['settings']['vertical_spacing'] ?? 'none';
+  $variables['vertical_spacing'] = $variables['settings']['vertical_spacing'] ?? 'auto';
 }

--- a/web/themes/contrib/civictheme/includes/layout.inc
+++ b/web/themes/contrib/civictheme/includes/layout.inc
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Layout related functions.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function civictheme_preprocess_layout__three_columns(array &$variables): void {
+  $variables['is_contained'] = $variables['settings']['is_contained'] ?? FALSE;
+  $variables['vertical_spacing'] = $variables['settings']['vertical_spacing'] ?? 'none';
+}

--- a/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
+++ b/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
@@ -37,6 +37,7 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
         'top' => $this->t('Top'),
         'bottom' => $this->t('Bottom'),
         'both' => $this->t('Both'),
+        'auto' => $this->t('Automatic'),
       ],
     ];
 

--- a/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
+++ b/web/themes/contrib/civictheme/src/Plugin/Layout/ThreeColumnsLayout.php
@@ -28,6 +28,18 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
       '#description' => $this->t('Check if the layout elements should be contained. Leave unchecked for edge-to-edge width. If sidebar regions are present - the layout will be contained regardless of this setting.'),
     ];
 
+    $form['vertical_spacing'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Vertical spacing'),
+      '#default_value' => $this->configuration['vertical_spacing'],
+      '#options' => [
+        'none' => $this->t('None'),
+        'top' => $this->t('Top'),
+        'bottom' => $this->t('Bottom'),
+        'both' => $this->t('Both'),
+      ],
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -37,6 +49,7 @@ class ThreeColumnsLayout extends LayoutDefault implements PluginFormInterface {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['is_contained'] = $form_state->getValue('is_contained');
+    $this->configuration['vertical_spacing'] = $form_state->getValue('vertical_spacing');
   }
 
 }

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -31,7 +31,8 @@
 {% set is_contained = settings.is_contained %}
 {% set is_contained = is_contained or has_sidebar_left or has_sidebar_right %}
 
-{% set vertical_spacing = has_sidebar_left or has_sidebar_right ? 'top' : vertical_spacing %}
+{% set vertical_spacing = vertical_spacing ? vertical_spacing : settings.vertical_spacing %}
+{% set vertical_spacing = vertical_spacing ? vertical_spacing : has_sidebar_left or has_sidebar_right ? 'top' : '' %}
 
 {% set no_sidebar_left_class = hide_sidebar_left ? 'ct-layout--no-sidebar-left' : '' %}
 {% set no_sidebar_right_class = hide_sidebar_right ? 'ct-layout--no-sidebar-right' : '' %}

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -30,7 +30,7 @@
 
 {% set is_contained = is_contained or has_sidebar_left or has_sidebar_right %}
 
-{% set vertical_spacing = vertical_spacing != 'none' ? vertical_spacing : has_sidebar_left or has_sidebar_right ? 'top' : '' %}
+{% set vertical_spacing = vertical_spacing != 'auto' ? vertical_spacing : has_sidebar_left or has_sidebar_right ? 'top' : '' %}
 
 {% set no_sidebar_left_class = hide_sidebar_left ? 'ct-layout--no-sidebar-left' : '' %}
 {% set no_sidebar_right_class = hide_sidebar_right ? 'ct-layout--no-sidebar-right' : '' %}

--- a/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
+++ b/web/themes/contrib/civictheme/templates/layout/layout--three-columns.html.twig
@@ -28,11 +28,9 @@
 {% set has_sidebar_left = (content.sidebar_top_left is not empty or content.sidebar_bottom_left is not empty) and not hide_sidebar_left|default(false) %}
 {% set has_sidebar_right = (content.sidebar_top_right is not empty or content.sidebar_bottom_right is not empty) and not hide_sidebar_right|default(false) %}
 
-{% set is_contained = settings.is_contained %}
 {% set is_contained = is_contained or has_sidebar_left or has_sidebar_right %}
 
-{% set vertical_spacing = vertical_spacing ? vertical_spacing : settings.vertical_spacing %}
-{% set vertical_spacing = vertical_spacing ? vertical_spacing : has_sidebar_left or has_sidebar_right ? 'top' : '' %}
+{% set vertical_spacing = vertical_spacing != 'none' ? vertical_spacing : has_sidebar_left or has_sidebar_right ? 'top' : '' %}
 
 {% set no_sidebar_left_class = hide_sidebar_left ? 'ct-layout--no-sidebar-left' : '' %}
 {% set no_sidebar_right_class = hide_sidebar_right ? 'ct-layout--no-sidebar-right' : '' %}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3476600

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. When creating a 3 col layout section in page builder, the option to configure vertical spacing (top, bottom, both) has now been added.

## Screenshots
![Screenshot 2024-09-25 at 3 58 10 pm](https://github.com/user-attachments/assets/0fefd5b7-a7c9-48d8-a501-9d9fa66294e2)
![Screenshot 2024-09-25 at 3 58 04 pm](https://github.com/user-attachments/assets/53553b9a-d4fd-4214-b168-d09c71dc28d5)
