### PR TITLE
Issue #3476889 - Fixed useEffect only running on load due to blank deps.

### DIFF
--- a/web/themes/contrib/civictheme/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/.storybook/preview.js
@@ -12,7 +12,7 @@ import { decoratorDocs } from '../components/00-base/storybook/storybook.docs.ut
 
 // Call attaching of behaviours.
 addDecorator((storyFn) => {
-  useEffect(() => Drupal.attachBehaviors(), []);
+  useEffect(() => Drupal.attachBehaviors());
   return storyFn();
 });
 

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.storybook/preview.js
@@ -12,7 +12,7 @@ import { decoratorDocs } from '../components_combined/00-base/storybook/storyboo
 
 // Call attaching of behaviours.
 addDecorator((storyFn) => {
-  useEffect(() => Drupal.attachBehaviors(), []);
+  useEffect(() => Drupal.attachBehaviors());
   return storyFn();
 });
 


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3476889

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. In React, passing a blank `[]` dependency into `useEffect()` will run the function on load. However, we want to re-run the Drupal.Behaviours on any prop change.

## Screenshots

https://github.com/user-attachments/assets/1eb5b42a-4a2f-4038-8fcb-189b98990a8d

