### PR TITLE
Fixed multiple checkboxes mistakenly marked as required if a Field is marked as required.

### DIFF
--- a/web/themes/contrib/civictheme/includes/form_element.inc
+++ b/web/themes/contrib/civictheme/includes/form_element.inc
@@ -191,6 +191,8 @@ function civictheme_preprocess_fieldset__form_element__civictheme_field__checkbo
       'id' => Html::cleanCssIdentifier($element['#id'] . '-' . $value),
       'is_checked' => is_array($element['#default_value']) ? in_array($value, $element['#default_value']) : $element['#default_value'] == $value,
       'is_disabled' => isset($element['#attributes']['disabled']),
+      // Checkboxes controls with a group cannot be required by definition.
+      'is_required' => FALSE,
       'attributes' => $attributes,
       'modifier_class' => $modifier_class,
     ];


### PR DESCRIPTION
This needs UIKit change to be merged https://github.com/civictheme/uikit/pull/405

Use case: webform field with multiple checkboxes marked as required makes all checkboxes required.