### PR TITLE
Issue #3500869 by silverham: Call to a member function setSyncing() on null if Drupal view is removed and post_update hook is run

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -778,8 +778,16 @@ function civictheme_post_update_import_subject_card_view_mode(): void {
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
 function civictheme_post_update_alert_visibility_validation(): string {
-  $view_config = \Drupal::configFactory()->getEditable('views.view.civictheme_alerts');
-  $view_config->set('display.default.display_options.fields.field_c_n_alert_page_visibility.alter.strip_tags', TRUE);
-  $view_config->save();
-  return (string) (new TranslatableMarkup('Updated alert api view to strip tags from visibility validation.'));
+  $config_name = 'views.view.civictheme_alerts';
+  $config_entity_type = 'view';
+  $id = substr($config_name, strpos($config_name, '.', 6) + 1);
+  $config_read = \Drupal::service('entity_type.manager')->getStorage($config_entity_type)->load($id);
+  // Only update config if it already exists.
+  if ($config_read) {
+    $config_object = \Drupal::configFactory()->getEditable($config_name);
+    $config_object->set('display.default.display_options.fields.field_c_n_alert_page_visibility.alter.strip_tags', TRUE);
+    $config_object->save();
+    return (string) (new TranslatableMarkup('Updated alert api view to strip tags from visibility validation.'));
+  }
+  return (string) (new TranslatableMarkup('Update to alert api view skipped, view does not exist.'));
 }

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -780,6 +780,9 @@ function civictheme_post_update_import_subject_card_view_mode(): void {
 function civictheme_post_update_alert_visibility_validation(): string {
   $config_name = 'views.view.civictheme_alerts';
   $config_entity_type = 'view';
+  // Get Remove the config prefix, so can get the id.
+  // @see Drupal\civictheme\CivicthemeUpdateHelper::deleteConfig().
+  // @see Drupal\Core\Config\Entity\ConfigEntityStorage\ConfigEntityStorage::getIDFromConfigName().
   $id = substr($config_name, strpos($config_name, '.', 6) + 1);
   $config_read = \Drupal::service('entity_type.manager')->getStorage($config_entity_type)->load($id);
   // Only update config if it already exists.


### PR DESCRIPTION
If the Drupal view `civictheme_alerts` is already deleted, then if you update `civictheme` to run `civictheme_post_update_alert_visibility_validation()`, then you get an error, `Call to a member function setSyncing() on null`, when running drush updb.

See Drupal issue: https://www.drupal.org/project/civictheme/issues/3500869
See related issue: https://www.drupal.org/project/drupal/issues/3051453

## Checklist before requesting a review

- [X] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [X] I have added a link to the issue tracker
https://www.drupal.org/project/civictheme/issues/3500869
- [X] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
Checking if config exists is standard.
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
Test not created minor fix. Very cumbersome to add test.
- [X] I have run new and existing relevant tests locally with my changes, and they passed
Ditto.
- [X] I have provided screenshots, where applicable
Screenshot not required
