### PR TITLE
[CIVIC-2067] Apply paragraph auto list theme to view & exposed filters.

### DIFF
--- a/web/themes/contrib/civictheme/includes/automated_list.inc
+++ b/web/themes/contrib/civictheme/includes/automated_list.inc
@@ -61,6 +61,7 @@ function civictheme_preprocess_paragraph__civictheme_automated_list(array &$vari
   $settings['item_theme'] = civictheme_get_field_value($paragraph, 'field_c_p_list_item_theme');
   $settings['topics'] = civictheme_get_field_value($paragraph, 'field_c_p_list_topics');
   $settings['site_sections'] = civictheme_get_field_value($paragraph, 'field_c_p_list_site_sections');
+  $settings['theme'] = $variables['theme'];
   _civictheme_preprocess_paragraph__paragraph_field__theme($settings);
   _civictheme_preprocess_paragraph__paragraph_field__title($settings);
   _civictheme_preprocess_paragraph__paragraph_field__column_count($settings);

--- a/web/themes/contrib/civictheme/includes/views.inc
+++ b/web/themes/contrib/civictheme/includes/views.inc
@@ -34,6 +34,8 @@ function _civictheme_preprocess_views_view__view(array &$variables): void {
 
   $variables['attributes']['class'] = empty($variables['dom_id']) ? Html::getUniqueId('js-view-dom-id') : 'js-view-dom-id-' . $variables['dom_id'];
 
+  $variables['theme'] = $view->component_settings['theme'];
+
   // @phpstan-ignore-next-line
   if (!empty($view->header) && is_array($view->header)) {
     // Extract 'results' into own variable.
@@ -50,6 +52,7 @@ function _civictheme_preprocess_views_view__view(array &$variables): void {
 
   // Render 'exposed' as Filters component.
   if (!empty($variables['exposed'])) {
+    $variables['exposed']['#attributes']['#civictheme_theme'] = $variables['theme'];
     $variables['filters'] = $variables['exposed'];
     unset($variables['exposed']);
   }
@@ -144,7 +147,15 @@ function civictheme_preprocess_views_exposed_form(array &$variables): void {
     return;
   }
 
-  $field_count = count(_civictheme_form_get_form_elements($variables['form']));
+  $fields = _civictheme_form_get_form_elements($variables['form']);
+  $field_count = count($fields);
+
+  // Apply theme on fields.
+  if ($field_count > 0) {
+    foreach ($fields as $key => $value) {
+      $variables['form'][$key]['#attributes']['#civictheme_theme'] = $variables['attributes']['#civictheme_theme'];
+    }
+  }
 
   if ($field_count == 1) {
     _civictheme_preprocess_views__exposed_form__single_filter($variables);
@@ -197,7 +208,7 @@ function _civictheme_preprocess_views__exposed_form__single_filter(array &$varia
 
   $variables['is_multiple'] = $is_multiple;
   $variables['filter_title'] = $field['#description'] ?? t('Filter search results');
-  $variables['theme'] = $variables['theme'] ?? CivicthemeConstants::THEME_LIGHT;
+  $variables['theme'] = $variables['attributes']['#civictheme_theme'];
 
   _civictheme_form_preprocess_hidden_form_elements($variables);
 
@@ -231,7 +242,7 @@ function _civictheme_preprocess_views__exposed_form__group_filter(array &$variab
 
   $variables['filters'] = $filters;
   $variables['filter_title'] = $field['#description'] ?? t('Filter search results');
-  $variables['theme'] = $variables['theme'] ?? CivicthemeConstants::THEME_LIGHT;
+  $variables['theme'] = $variables['attributes']['#civictheme_theme'];
 
   _civictheme_form_preprocess_hidden_form_elements($variables);
 


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3505931
https://salsadigital.atlassian.net/browse/CIVIC-2067

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. The theme configured on the automated list paragraph is now correctly propagated to the exposed filters and fields.

## Screenshots
