### PR TITLE
Issue #3513583 by alan.cole, danielgry, fionamorrison23: Updated skip link to use id on the main, or banner element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.9.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#13e708ba7dfc42ad6ed75f78ae6f80cacfe73751",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#16aaff9a17a9b530168beeffb10a175450e4e20b",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@popperjs/core": "^2.11.8"

--- a/web/themes/contrib/civictheme/includes/banner.inc
+++ b/web/themes/contrib/civictheme/includes/banner.inc
@@ -73,6 +73,8 @@ function _civictheme_preprocess_block__civictheme_banner(array &$variables): voi
 
   // 'type' is internal field and should not be passed to the template.
   unset($variables['type']);
+  // 'attributes' field includes an id which conflicts with the template `main-content` id.
+  unset($variables['attributes']);
 }
 
 /**

--- a/web/themes/contrib/civictheme/package-lock.json
+++ b/web/themes/contrib/civictheme/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@civictheme/uikit": "github:civictheme/uikit#13e708ba7dfc42ad6ed75f78ae6f80cacfe73751",
+        "@civictheme/uikit": "github:civictheme/uikit#16aaff9a17a9b530168beeffb10a175450e4e20b",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -79,8 +79,8 @@
     },
     "node_modules/@civictheme/uikit": {
       "version": "1.9.0",
-      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#13e708ba7dfc42ad6ed75f78ae6f80cacfe73751",
-      "integrity": "sha512-LBVHniVHRC2He/mGfgr1BJ+FY4IsIx6ux2pcfYW7iNHyB9xq/UbMbcjKZOlKM88wbje1gT1UcmaoKZrVcGOYlA==",
+      "resolved": "git+ssh://git@github.com/civictheme/uikit.git#16aaff9a17a9b530168beeffb10a175450e4e20b",
+      "integrity": "sha512-HczPLfCf0aJCoLeQ38kzdyW4vl8O074w9SnRpRTW8gToIyVSuU9rLIScBO4Zk50LrVOcwLQpLmBXxd8RcV7X+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@popperjs/core": "^2.11.8"

--- a/web/themes/contrib/civictheme/package.json
+++ b/web/themes/contrib/civictheme/package.json
@@ -27,7 +27,7 @@
     "uikit-install": "rm -Rf components > /dev/null 2>&1 && cp -R node_modules/@civictheme/uikit/components components"
   },
   "dependencies": {
-    "@civictheme/uikit": "github:civictheme/uikit#13e708ba7dfc42ad6ed75f78ae6f80cacfe73751",
+    "@civictheme/uikit": "github:civictheme/uikit#16aaff9a17a9b530168beeffb10a175450e4e20b",
     "@popperjs/core": "^2.11.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Issue Link: https://www.drupal.org/project/civictheme/issues/3513583

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Complimentary PR to [UI Kit PR](https://github.com/civictheme/uikit/pull/507) to add id to banner - this removes the second id being set on banners.

## Screenshots
<img width="1007" alt="Screenshot 2025-03-07 at 10 24 07 pm" src="https://github.com/user-attachments/assets/d04585d9-e229-4c27-a3f5-65a372421a32" />
