### PR TITLE
Issue #3516354: Update update script to automatically find CivicTheme directory

### DIFF
--- a/tests/phpunit/CivicthemeCreateSubthemeScriptUnitTest.php
+++ b/tests/phpunit/CivicthemeCreateSubthemeScriptUnitTest.php
@@ -136,8 +136,6 @@ class CivicthemeCreateSubthemeScriptUnitTest extends ScriptUnitTestBase {
     $this->assertFileExists($expected_new_theme_dir_full . 'README.md');
     $this->assertFileExists($expected_new_theme_dir_full . 'screenshot.png');
 
-    $this->assertStringContainsString($expected_rel_path, (string) file_get_contents($expected_new_theme_dir_full . 'build.js'));
-
     $composerjson_actual = json_decode((string) file_get_contents($expected_new_theme_dir_full . 'composer.json'), TRUE);
     $this->assertStringContainsString($composerjson['version'], $composerjson_actual['extra']['civictheme']['version']);
     $this->assertStringContainsString($composerjson['homepage'], $composerjson_actual['extra']['civictheme']['homepage']);
@@ -248,8 +246,6 @@ class CivicthemeCreateSubthemeScriptUnitTest extends ScriptUnitTestBase {
     $this->assertFileExists($expected_new_theme_dir_full . 'package.json');
     $this->assertFileExists($expected_new_theme_dir_full . 'README.md');
     $this->assertFileExists($expected_new_theme_dir_full . 'screenshot.png');
-
-    $this->assertStringContainsString($expected_rel_path, (string) file_get_contents($expected_new_theme_dir_full . 'build.js'));
 
     // Examples assertions.
     $this->assertDirectoryDoesNotExist($expected_new_theme_dir_full . 'components/01-atoms/demo-button');

--- a/tests/phpunit/CivicthemeCreateSubthemeScriptUnitTest.php
+++ b/tests/phpunit/CivicthemeCreateSubthemeScriptUnitTest.php
@@ -82,7 +82,7 @@ class CivicthemeCreateSubthemeScriptUnitTest extends ScriptUnitTestBase {
    * @dataProvider dataProviderTestLocation
    * @runInSeparateProcess
    */
-  public function testLocation(string $civictheme_dir, string $newtheme_rel_dir, string $expected_newtheme_dir, string $expected_rel_path): void {
+  public function testLocation(string $civictheme_dir, string $newtheme_rel_dir, string $expected_newtheme_dir): void {
     $newtheme_name = 'new_theme';
 
     $sut_dir = $this->prepareSut($civictheme_dir);
@@ -210,7 +210,6 @@ class CivicthemeCreateSubthemeScriptUnitTest extends ScriptUnitTestBase {
     $newtheme_rel_dir = '';
     $newtheme_name = 'new_theme';
     $expected_newtheme_dir = 'web/themes/custom/new_theme';
-    $expected_rel_path = '../../contrib/civictheme/';
 
     $this->prepareSut($civictheme_dir);
     $expected_new_theme_dir_full = $this->tmpDir . '/' . $expected_newtheme_dir;

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -442,7 +442,7 @@ function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   }
   errorReporter({
     message: 'Could not find civictheme directory.',
-    formatted: `Could not find directory '${basePath}${civicthemeDir}'`,
+    formatted: basePath ? `Could not find directory '${basePath}${civicthemeDir}'` : `Could not find directory '${parent}'`,
   }, true)
 }
 

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -442,7 +442,7 @@ function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   }
   errorReporter({
     message: 'Could not find civictheme directory.',
-    formatted: basePath ? `Could not find directory '${basePath}${civicthemeDir}'` : `Could not find directory '${parent}'`,
+    formatted: `Could not find directory '${basePath ? `${basePath}${civicthemeDir}` : parent}'`
   }, true)
 }
 

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -78,7 +78,7 @@ let lastTime = null
 const PATH = import.meta.dirname
 
 const THEME_NAME                = PATH.split('/').reverse()[0]
-const DIR_CIVICTHEME            = fullPath('../../contrib/civictheme/')
+const DIR_CIVICTHEME            = getCivicthemeDir(PATH)
 const DIR_COMPONENTS_IN         = fullPath('./components/')
 const DIR_COMPONENTS_OUT        = fullPath('./components_combined/')
 const DIR_UIKIT_COMPONENTS_IN   = `${DIR_CIVICTHEME}/components/`
@@ -145,6 +145,21 @@ if (config.lintex) {
 }
 
 // ----------------------------------------------------------------------------- BUILD STEPS
+
+function getCivicthemeDir(subthemeDir) {
+  let currentDir = subthemeDir
+  successReporter(`Feb currentDir inside civictheme: ${currentDir}`)
+  while (currentDir !== path.parse(currentDir).root) {
+    if (path.parse(currentDir).name === 'themes') {
+      const civicthemePath = globSync(currentDir + '/**/civictheme').pop()
+      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
+        return path.resolve(civicthemePath)
+      }
+    }
+    currentDir = path.dirname(currentDir)
+  }
+  errorReporter('Could not find civictheme directory.')
+}
 
 function buildOutDirectory() {
   if (!fs.existsSync(DIR_OUT)) {

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -431,15 +431,14 @@ function fullPath(filepath) {
 }
 
 function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
-  let currentDir = subthemeDir
-  while (currentDir !== path.parse(currentDir).root) {
-    if (path.parse(currentDir).name === parent) {
-      const civicthemePath = globSync(`${currentDir}${civicthemeDir}`).pop()
-      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
-        return path.resolve(civicthemePath)
-      }
+  const pathParts = subthemeDir.split('/')
+  const parentIndex = pathParts.indexOf(parent)
+  if (parentIndex >= 0) {
+    const basePath = pathParts.slice(0, parentIndex + 1).join('/')
+    const civicthemePath = globSync(`${basePath}${civicthemeDir}`).pop()
+    if (civicthemePath) {
+      return civicthemePath
     }
-    currentDir = path.dirname(currentDir)
   }
   errorReporter('Could not find civictheme directory.')
 }

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -78,14 +78,15 @@ let lastTime = null
 const PATH = import.meta.dirname
 
 const THEME_NAME                = PATH.split('/').reverse()[0]
-const DIR_CIVICTHEME            = getCivicthemeDir(PATH)
 const DIR_COMPONENTS_IN         = fullPath('./components/')
-const DIR_COMPONENTS_OUT        = fullPath('./components_combined/')
-const DIR_UIKIT_COMPONENTS_IN   = `${DIR_CIVICTHEME}/components/`
-const DIR_UIKIT_COPY_OUT        = fullPath('./.components-civictheme/')
 const DIR_OUT                   = fullPath('./dist/')
 const DIR_ASSETS_IN             = fullPath('./assets/')
 const DIR_ASSETS_OUT            = fullPath('./dist/assets/')
+
+const DIR_CIVICTHEME            = config.base ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
+const DIR_UIKIT_COMPONENTS_IN   = config.base ? null : `${DIR_CIVICTHEME}/components/`
+const DIR_UIKIT_COPY_OUT        = config.base ? null : fullPath('./.components-civictheme/')
+const DIR_COMPONENTS_OUT        = config.base ? null : fullPath('./components_combined/')
 
 const COMPONENT_DIR             = config.base ? DIR_COMPONENTS_IN : DIR_COMPONENTS_OUT
 const STYLE_NAME                = config.base ? 'civictheme' : 'styles'
@@ -117,9 +118,9 @@ const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
 const JS_CIVIC_IMPORTS          = `${COMPONENT_DIR}/**/!(*.stories|*.stories.data|*.component|*.min|*.test|*.script|*.utils).js`
 const JS_LIB_IMPORTS            = [fullPath('./node_modules/@popperjs/core/dist/umd/popper.js')]
 const JS_ASSET_IMPORTS          = [
-                                    `${DIR_CIVICTHEME}/assets/js/**/*.js`,
+                                    DIR_CIVICTHEME ? `${DIR_CIVICTHEME}/assets/js/**/*.js` : false,
                                     `${DIR_ASSETS_IN}/js/**/*.js`,
-                                  ]
+                                  ].filter(Boolean)
 const JS_LINT_EXCLUSION_HEADER  = '// phpcs:ignoreFile'
 
 const CONSTANTS_FILE_OUT        = `${DIR_OUT}/constants.json`
@@ -145,21 +146,6 @@ if (config.lintex) {
 }
 
 // ----------------------------------------------------------------------------- BUILD STEPS
-
-function getCivicthemeDir(subthemeDir) {
-  let currentDir = subthemeDir
-  successReporter(`Feb currentDir inside civictheme: ${currentDir}`)
-  while (currentDir !== path.parse(currentDir).root) {
-    if (path.parse(currentDir).name === 'themes') {
-      const civicthemePath = globSync(currentDir + '/**/civictheme').pop()
-      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
-        return path.resolve(civicthemePath)
-      }
-    }
-    currentDir = path.dirname(currentDir)
-  }
-  errorReporter('Could not find civictheme directory.')
-}
 
 function buildOutDirectory() {
   if (!fs.existsSync(DIR_OUT)) {
@@ -442,6 +428,20 @@ function stripJS(js) {
 
 function fullPath(filepath) {
   return path.resolve(PATH, filepath)
+}
+
+function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
+  let currentDir = subthemeDir
+  while (currentDir !== path.parse(currentDir).root) {
+    if (path.parse(currentDir).name === parent) {
+      const civicthemePath = globSync(`${currentDir}${civicthemeDir}`).pop()
+      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
+        return path.resolve(civicthemePath)
+      }
+    }
+    currentDir = path.dirname(currentDir)
+  }
+  errorReporter('Could not find civictheme directory.')
 }
 
 function time(full) {

--- a/web/themes/contrib/civictheme/build.js
+++ b/web/themes/contrib/civictheme/build.js
@@ -433,14 +433,17 @@ function fullPath(filepath) {
 function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   const pathParts = subthemeDir.split('/')
   const parentIndex = pathParts.indexOf(parent)
-  if (parentIndex >= 0) {
-    const basePath = pathParts.slice(0, parentIndex + 1).join('/')
-    const civicthemePath = globSync(`${basePath}${civicthemeDir}`).pop()
+  const basePath = parentIndex >= 0 ? pathParts.slice(0, parentIndex + 1).join('/') : null
+  if (basePath) {
+    const civicthemePath = globSync(`${basePath}${civicthemeDir}`, { ignore: 'node_modules/**' }).pop()
     if (civicthemePath) {
       return civicthemePath
     }
   }
-  errorReporter('Could not find civictheme directory.')
+  errorReporter({
+    message: 'Could not find civictheme directory.',
+    formatted: `Could not find directory '${basePath}${civicthemeDir}'`,
+  }, true)
 }
 
 function time(full) {
@@ -450,9 +453,12 @@ function time(full) {
   return `[ ${rtn} ms ]`
 }
 
-function errorReporter(error) {
-  console.error('❌   Error during SASS compilation:', error.message);
+function errorReporter(error, fatal = false) {
+  console.error('❌   Error during build:', error.message);
   console.error('Details:', error.formatted || error);
+  if (fatal) {
+    process.exit(1)
+  }
 }
 
 function successReporter(message) {

--- a/web/themes/contrib/civictheme/civictheme_create_subtheme.php
+++ b/web/themes/contrib/civictheme/civictheme_create_subtheme.php
@@ -619,6 +619,49 @@ function file_tempdir(?string $dir = NULL, string $prefix = 'tmp_', int $mode = 
 }
 
 /**
+ * Get relative directory path from 2 directory paths.
+ *
+ * This function does not rely on existence of paths.
+ *
+ * @param string $dir1
+ *   First dir path to compare.
+ * @param string $dir2
+ *   Second dir path to compare.
+ *
+ * @return string
+ *   Relative path between 2 directories.
+ */
+function file_get_relative_dir(string $dir1, string $dir2): string {
+  $dir1 = rtrim($dir1, '/') . '/';
+  $dir2 = rtrim($dir2, '/') . '/';
+
+  if ($dir1 === $dir2) {
+    return './';
+  }
+
+  $dir1 = explode('/', $dir1);
+  $dir2 = explode('/', $dir2);
+  $parts = $dir2;
+
+  foreach ($dir1 as $depth => $dir) {
+    if ($dir === $dir2[$depth]) {
+      array_shift($parts);
+      continue;
+    }
+
+    $remaining = count($dir1) - $depth;
+    if ($remaining > 1) {
+      $parts = array_pad($parts, -1 * (count($parts) + $remaining - 1), '..');
+      break;
+    }
+
+    $parts[0] = './' . $parts[0];
+  }
+
+  return implode('/', $parts);
+}
+
+/**
  * Canonicalize the path by removing './' and '../'.
  *
  * @param string $path

--- a/web/themes/contrib/civictheme/civictheme_create_subtheme.php
+++ b/web/themes/contrib/civictheme/civictheme_create_subtheme.php
@@ -205,12 +205,6 @@ function process_stub(string $dir, array $options): void {
   // phpcs:enable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma
   // phpcs:enable Drupal.WhiteSpace.Comma.TooManySpaces
 
-  // Resolve CivicTheme's location relative to the new theme.
-  $current_dir = __DIR__;
-  $relative_dir = file_get_relative_dir($options['path'], $current_dir);
-  file_replace_file_content('../../contrib/civictheme/', $relative_dir, $dir . '/' . 'build.js');
-  file_replace_file_content('../../../contrib/civictheme/', $relative_dir, $dir . '/' . 'package.json');
-
   // Adjust per-file settings.
   //
   // Remove 'hidden: true' from the info.
@@ -596,7 +590,7 @@ function file_is_excluded_from_processing(string $filename): bool {
  *
  * @SuppressWarnings(PHPMD.MissingImport)
  */
-function file_tempdir(string $dir = NULL, string $prefix = 'tmp_', int $mode = 0700, int $max_attempts = 1000): string {
+function file_tempdir(?string $dir = NULL, string $prefix = 'tmp_', int $mode = 0700, int $max_attempts = 1000): string {
   if (is_null($dir)) {
     $dir = sys_get_temp_dir();
   }
@@ -622,49 +616,6 @@ function file_tempdir(string $dir = NULL, string $prefix = 'tmp_', int $mode = 0
   }
 
   return $path;
-}
-
-/**
- * Get relative directory path from 2 directory paths.
- *
- * This function does not rely on existence of paths.
- *
- * @param string $dir1
- *   First dir path to compare.
- * @param string $dir2
- *   Second dir path to compare.
- *
- * @return string
- *   Relative path between 2 directories.
- */
-function file_get_relative_dir(string $dir1, string $dir2): string {
-  $dir1 = rtrim($dir1, '/') . '/';
-  $dir2 = rtrim($dir2, '/') . '/';
-
-  if ($dir1 === $dir2) {
-    return './';
-  }
-
-  $dir1 = explode('/', $dir1);
-  $dir2 = explode('/', $dir2);
-  $parts = $dir2;
-
-  foreach ($dir1 as $depth => $dir) {
-    if ($dir === $dir2[$depth]) {
-      array_shift($parts);
-      continue;
-    }
-
-    $remaining = count($dir1) - $depth;
-    if ($remaining > 1) {
-      $parts = array_pad($parts, -1 * (count($parts) + $remaining - 1), '..');
-      break;
-    }
-
-    $parts[0] = './' . $parts[0];
-  }
-
-  return implode('/', $parts);
 }
 
 /**

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -78,14 +78,15 @@ let lastTime = null
 const PATH = import.meta.dirname
 
 const THEME_NAME                = PATH.split('/').reverse()[0]
-const DIR_CIVICTHEME            = getCivicthemeDir(PATH)
 const DIR_COMPONENTS_IN         = fullPath('./components/')
-const DIR_COMPONENTS_OUT        = fullPath('./components_combined/')
-const DIR_UIKIT_COMPONENTS_IN   = `${DIR_CIVICTHEME}/components/`
-const DIR_UIKIT_COPY_OUT        = fullPath('./.components-civictheme/')
 const DIR_OUT                   = fullPath('./dist/')
 const DIR_ASSETS_IN             = fullPath('./assets/')
 const DIR_ASSETS_OUT            = fullPath('./dist/assets/')
+
+const DIR_CIVICTHEME            = config.base ? null : getCivicthemeDir(PATH, 'themes', '/**/civictheme')
+const DIR_UIKIT_COMPONENTS_IN   = config.base ? null : `${DIR_CIVICTHEME}/components/`
+const DIR_UIKIT_COPY_OUT        = config.base ? null : fullPath('./.components-civictheme/')
+const DIR_COMPONENTS_OUT        = config.base ? null : fullPath('./components_combined/')
 
 const COMPONENT_DIR             = config.base ? DIR_COMPONENTS_IN : DIR_COMPONENTS_OUT
 const STYLE_NAME                = config.base ? 'civictheme' : 'styles'
@@ -117,9 +118,9 @@ const JS_STORYBOOK_FILE_OUT     = `${DIR_OUT}/${SCRIPT_NAME}.storybook.js`
 const JS_CIVIC_IMPORTS          = `${COMPONENT_DIR}/**/!(*.stories|*.stories.data|*.component|*.min|*.test|*.script|*.utils).js`
 const JS_LIB_IMPORTS            = [fullPath('./node_modules/@popperjs/core/dist/umd/popper.js')]
 const JS_ASSET_IMPORTS          = [
-                                    `${DIR_CIVICTHEME}/assets/js/**/*.js`,
+                                    DIR_CIVICTHEME ? `${DIR_CIVICTHEME}/assets/js/**/*.js` : false,
                                     `${DIR_ASSETS_IN}/js/**/*.js`,
-                                  ]
+                                  ].filter(Boolean)
 const JS_LINT_EXCLUSION_HEADER  = '// phpcs:ignoreFile'
 
 const CONSTANTS_FILE_OUT        = `${DIR_OUT}/constants.json`
@@ -145,20 +146,6 @@ if (config.lintex) {
 }
 
 // ----------------------------------------------------------------------------- BUILD STEPS
-
-function getCivicthemeDir(subthemeDir) {
-  let currentDir = subthemeDir
-  while (currentDir !== path.parse(currentDir).root) {
-    if (path.parse(currentDir).name === 'themes') {
-      const civicthemePath = globSync(currentDir + '/**/civictheme').pop()
-      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
-        return path.resolve(civicthemePath)
-      }
-    }
-    currentDir = path.dirname(currentDir)
-  }
-  errorReporter('Could not find civictheme directory.')
-}
 
 function buildOutDirectory() {
   if (!fs.existsSync(DIR_OUT)) {
@@ -441,6 +428,20 @@ function stripJS(js) {
 
 function fullPath(filepath) {
   return path.resolve(PATH, filepath)
+}
+
+function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
+  let currentDir = subthemeDir
+  while (currentDir !== path.parse(currentDir).root) {
+    if (path.parse(currentDir).name === parent) {
+      const civicthemePath = globSync(`${currentDir}${civicthemeDir}`).pop()
+      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
+        return path.resolve(civicthemePath)
+      }
+    }
+    currentDir = path.dirname(currentDir)
+  }
+  errorReporter('Could not find civictheme directory.')
 }
 
 function time(full) {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -442,7 +442,7 @@ function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   }
   errorReporter({
     message: 'Could not find civictheme directory.',
-    formatted: `Could not find directory '${basePath}${civicthemeDir}'`,
+    formatted: basePath ? `Could not find directory '${basePath}${civicthemeDir}'` : `Could not find directory '${parent}'`,
   }, true)
 }
 

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -442,7 +442,7 @@ function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   }
   errorReporter({
     message: 'Could not find civictheme directory.',
-    formatted: basePath ? `Could not find directory '${basePath}${civicthemeDir}'` : `Could not find directory '${parent}'`,
+    formatted: `Could not find directory '${basePath ? `${basePath}${civicthemeDir}` : parent}'`
   }, true)
 }
 

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -78,7 +78,7 @@ let lastTime = null
 const PATH = import.meta.dirname
 
 const THEME_NAME                = PATH.split('/').reverse()[0]
-const DIR_CIVICTHEME            = fullPath('../../contrib/civictheme/')
+const DIR_CIVICTHEME            = getCivicthemeDir(PATH)
 const DIR_COMPONENTS_IN         = fullPath('./components/')
 const DIR_COMPONENTS_OUT        = fullPath('./components_combined/')
 const DIR_UIKIT_COMPONENTS_IN   = `${DIR_CIVICTHEME}/components/`
@@ -145,6 +145,20 @@ if (config.lintex) {
 }
 
 // ----------------------------------------------------------------------------- BUILD STEPS
+
+function getCivicthemeDir(subthemeDir) {
+  let currentDir = subthemeDir
+  while (currentDir !== path.parse(currentDir).root) {
+    if (path.parse(currentDir).name === 'themes') {
+      const civicthemePath = globSync(currentDir + '/**/civictheme').pop()
+      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
+        return path.resolve(civicthemePath)
+      }
+    }
+    currentDir = path.dirname(currentDir)
+  }
+  errorReporter('Could not find civictheme directory.')
+}
 
 function buildOutDirectory() {
   if (!fs.existsSync(DIR_OUT)) {

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -431,15 +431,14 @@ function fullPath(filepath) {
 }
 
 function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
-  let currentDir = subthemeDir
-  while (currentDir !== path.parse(currentDir).root) {
-    if (path.parse(currentDir).name === parent) {
-      const civicthemePath = globSync(`${currentDir}${civicthemeDir}`).pop()
-      if (fs.existsSync(civicthemePath) && fs.lstatSync(civicthemePath).isDirectory()) {
-        return path.resolve(civicthemePath)
-      }
+  const pathParts = subthemeDir.split('/')
+  const parentIndex = pathParts.indexOf(parent)
+  if (parentIndex >= 0) {
+    const basePath = pathParts.slice(0, parentIndex + 1).join('/')
+    const civicthemePath = globSync(`${basePath}${civicthemeDir}`).pop()
+    if (civicthemePath) {
+      return civicthemePath
     }
-    currentDir = path.dirname(currentDir)
   }
   errorReporter('Could not find civictheme directory.')
 }

--- a/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/build.js
@@ -433,14 +433,17 @@ function fullPath(filepath) {
 function getCivicthemeDir(subthemeDir, parent, civicthemeDir) {
   const pathParts = subthemeDir.split('/')
   const parentIndex = pathParts.indexOf(parent)
-  if (parentIndex >= 0) {
-    const basePath = pathParts.slice(0, parentIndex + 1).join('/')
-    const civicthemePath = globSync(`${basePath}${civicthemeDir}`).pop()
+  const basePath = parentIndex >= 0 ? pathParts.slice(0, parentIndex + 1).join('/') : null
+  if (basePath) {
+    const civicthemePath = globSync(`${basePath}${civicthemeDir}`, { ignore: 'node_modules/**' }).pop()
     if (civicthemePath) {
       return civicthemePath
     }
   }
-  errorReporter('Could not find civictheme directory.')
+  errorReporter({
+    message: 'Could not find civictheme directory.',
+    formatted: `Could not find directory '${basePath}${civicthemeDir}'`,
+  }, true)
 }
 
 function time(full) {
@@ -450,9 +453,12 @@ function time(full) {
   return `[ ${rtn} ms ]`
 }
 
-function errorReporter(error) {
-  console.error('❌   Error during SASS compilation:', error.message);
+function errorReporter(error, fatal = false) {
+  console.error('❌   Error during build:', error.message);
   console.error('Details:', error.formatted || error);
+  if (fatal) {
+    process.exit(1)
+  }
 }
 
 function successReporter(message) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Issues:
- Jira: https://salsadigital.atlassian.net/browse/CIVIC-2142
- Drupal: https://www.drupal.org/project/civictheme/issues/3516354

## Changed

1. This script update provides a way for subthemes to automatically find the civictheme base class, assuming that the subtheme and base theme both live in the `themes` folder in Drupal.
2. This change was needed because the location of the civictheme base class can be different per implementation. Some projects use `/contrib/` and `/custom/`, some put all themes in the same parent directory.
3. If the parent theme is expected to live in a vastly different directory, the base theme class can still be set manually, e.g.


```js
const DIR_CIVICTHEME = config.base ? null : `/any/directory/path/civictheme`
```

4. This change also implements a few more checks for `config.base ? null : ...` for other variables. This is because some variables are only required if building for subtheme. This change, as well as avoiding setting variables that aren't required, also makes it clearer which variables are not used with the base theme.

## Screenshots
