### PR TITLE
Issue #3518342 by jdleonard: hook_civictheme_automated_list_view_info_alter example's content type is misleading

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.api.php
+++ b/web/themes/contrib/civictheme/civictheme.api.php
@@ -47,7 +47,7 @@ use Drupal\views\ViewExecutable;
 function hook_civictheme_automated_list_view_info_alter(array &$info, array $settings): void {
   // Change the view name and block based on the conditions set in the
   // Automated list settings.
-  if ($settings['content_type'] == 'event') {
+  if ($settings['content_type'] == 'civictheme_event') {
     // Use a custom display name for 'Event' content type.
     $info['display_name'] = 'my_custom_block_1';
   }


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3518342

One string change in API example code to help others avoid confusion