### PR TITLE
Issue #3518669 by jdleonard: Search displays least relevant search results first

### DIFF
--- a/web/themes/contrib/civictheme/config/optional/views.view.civictheme_search.yml
+++ b/web/themes/contrib/civictheme/config/optional/views.view.civictheme_search.yml
@@ -130,7 +130,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: search_api
-          order: ASC
+          order: DESC
           expose:
             label: ''
             field_identifier: ''


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3518669

View search order was Ascending, should be Descending.