### PR TITLE
#3522101 Fixed exception thrown when a filter has no label set.

### DIFF
--- a/web/themes/contrib/civictheme/includes/views.inc
+++ b/web/themes/contrib/civictheme/includes/views.inc
@@ -235,7 +235,7 @@ function _civictheme_preprocess_views__exposed_form__group_filter(array &$variab
   foreach ($fields as $field) {
     $filter = [
       'content' => civictheme_render($field),
-      'title' => $field['#title'],
+      'title' => $field['#title'] ?? NULL,
     ];
 
     $filters[] = $filter;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Fixed an error thrown for an Automated List filters when a label is not set.

