### PR TITLE
Issue #3522098: Added passing of the CSS class from view display to a template for Automated List

### DIFF
--- a/web/themes/contrib/civictheme/includes/automated_list.inc
+++ b/web/themes/contrib/civictheme/includes/automated_list.inc
@@ -92,6 +92,12 @@ function civictheme_preprocess_paragraph__civictheme_automated_list(array &$vari
   // Render view as rows.
   $variables['rows'] = $view->executeDisplay();
 
+  // Pass the CSS class from the view display to the template.
+  $css_class = $view->getDisplay()->getOption('css_class');
+  if (!empty($css_class)) {
+    $variables['modifier_class'] = $variables['modifier_class'] ?? '' . $css_class;
+  }
+
   // Add unique HTML ID.
   $attributes = [];
   $attributes['id'] = Html::getUniqueId('ct-automated-list-' . $paragraph->id());


### PR DESCRIPTION
<img width="1335" alt="SCR-20250430-mxmc" src="https://github.com/user-attachments/assets/d4f87219-7365-43a6-8ef6-290e604b57bc" />
