### PR TITLE
[#3522639] Fixed alerts not showing on CivicTheme pages.

### DIFF
--- a/tests/behat/features/content_type.civictheme_alert.view.feature
+++ b/tests/behat/features/content_type.civictheme_alert.view.feature
@@ -1,4 +1,4 @@
-@p1 @civictheme @content_type @civictheme_alert @skipped
+@p1 @civictheme @content_type @civictheme_alert
 Feature: CivicTheme Alert content type render
 
   Background:

--- a/tests/behat/features/toc.render.feature
+++ b/tests/behat/features/toc.render.feature
@@ -1,4 +1,4 @@
-@p0 @civictheme @civictheme_toc @skipped
+@p0 @civictheme @civictheme_toc
 Feature: Table Of Contents render
 
   @api @javascript
@@ -16,7 +16,7 @@ Feature: Table Of Contents render
 
     When I visit civictheme_page "[TEST] Page - toc"
     And wait 5 seconds
-    Then I should see a ".table-of-contents-container" element
+    Then I should see a "[data-table-of-contents-title]" element
     And I should see a visible ".ct-table-of-contents__title" element
     And I should see the text "On this page"
     And I should see "Test heading 1" in the ".ct-table-of-contents__links" element

--- a/web/themes/contrib/civictheme/civictheme.theme
+++ b/web/themes/contrib/civictheme/civictheme.theme
@@ -264,4 +264,7 @@ function civictheme_page_attachments_alter(array &$attachments) {
   if ($current_user->isAuthenticated()) {
     $attachments['#attached']['library'][] = 'civictheme/admin';
   }
+  $component_plugin_manager = \Drupal::service('plugin.manager.sdc');
+  $alert = $component_plugin_manager->find('civictheme:alert');
+  $attachments['#attached']['library'][] = $alert->getLibraryName();
 }

--- a/web/themes/contrib/civictheme/civictheme.theme
+++ b/web/themes/contrib/civictheme/civictheme.theme
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Core\Render\Component\Exception\ComponentNotFoundException;
 
 require_once __DIR__ . '/includes/utilities.inc';
 require_once __DIR__ . '/includes/process.inc';
@@ -264,7 +265,13 @@ function civictheme_page_attachments_alter(array &$attachments) {
   if ($current_user->isAuthenticated()) {
     $attachments['#attached']['library'][] = 'civictheme/admin';
   }
+  /** @var \Drupal\Core\Theme\ComponentPluginManager $component_plugin_manager */
   $component_plugin_manager = \Drupal::service('plugin.manager.sdc');
-  $alert = $component_plugin_manager->find('civictheme:alert');
-  $attachments['#attached']['library'][] = $alert->getLibraryName();
+  try {
+    $alert = $component_plugin_manager->find('civictheme:alert');
+    $attachments['#attached']['library'][] = $alert->getLibraryName();
+  }
+  catch (ComponentNotFoundException $exception) {
+    \Drupal::logger('civictheme')->error('Unable to find alert component: %message', ['%message' => $exception->getMessage()]);
+  }
 }

--- a/web/themes/contrib/civictheme/includes/node.inc
+++ b/web/themes/contrib/civictheme/includes/node.inc
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use Drupal\civictheme\CivicthemeConstants;
-use Drupal\Core\Template\Attribute;
 use Drupal\node\NodeInterface;
 
 /**


### PR DESCRIPTION
## JIRA ticket: #3522639

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. Added alert component libraries via civictheme_page_attachments_alter.
2. Updated TOC test (was skipping)

No change to components required.

## Screenshots

![image](https://github.com/user-attachments/assets/7a7fce4e-843c-4fee-ae52-1d133a7deeb7)
