### PR TITLE
Issue #3527810 by alan.cole: Fix for striptags error on webform message.

### DIFF
--- a/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
+++ b/web/themes/contrib/civictheme/templates/misc/status-messages.html.twig
@@ -8,8 +8,8 @@
   {% for message in messages %}
     {% include 'civictheme:message' with {
       title: status_headings[type] ? status_headings[type] : type|capitalize,
-      description: message,
-      type: type == 'status' ? 'information' : type,
+      description: message|render,
+      type: (type == 'status' or type == 'info') ? 'information' : type,
     } only %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3527810

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Error was occurring in `message.twig` component because prop `description` was being passed a render object rather than a string.
2. Webform message was setting `type` as `info` rather than `information`, so converting to `information` adds blue background to message component.

## Screenshots
Error:
![Screen Shot 2025-06-02 at 13 40 56](https://github.com/user-attachments/assets/073d47c9-37e0-4037-8aa7-c484fe1fa5d7)
Display after fix:
![Screenshot 2025-06-02 at 1 44 30 pm](https://github.com/user-attachments/assets/dd44ea24-06bc-4e72-a21f-1ab0603bb156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how status and info messages are displayed for greater consistency and clarity.
  - Enhanced message rendering to better support formatted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->