### PR TITLE
[CIVIC-2238] - Removing config dependency around workflow

### DIFF
--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_component_block.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_component_block.default.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - block_content.type.civictheme_component_block
     - field.field.block_content.civictheme_component_block.field_c_b_components
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - paragraphs

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_mobile_navigation.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_mobile_navigation.default.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_top
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_text
     - field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - field_group

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_search.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_search.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - block_content.type.civictheme_search
     - field.field.block_content.civictheme_search.field_c_b_link
     - field.field.block_content.civictheme_search.field_c_b_link_in_mobile_menu
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - link

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_social_links.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.block_content.civictheme_social_links.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.field.block_content.civictheme_social_links.field_c_b_social_icons
     - field.field.block_content.civictheme_social_links.field_c_b_theme
     - field.field.block_content.civictheme_social_links.field_c_b_with_border
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - paragraphs

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_audio.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_audio.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.field.media.civictheme_audio.field_c_m_audio_file
     - field.field.media.civictheme_audio.field_c_m_media_tags
     - media.type.civictheme_audio
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - file

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_document.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_document.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.field.media.civictheme_document.field_c_m_document
     - field.field.media.civictheme_document.field_c_m_media_tags
     - media.type.civictheme_document
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - file

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_icon.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_icon.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.field.media.civictheme_icon.field_c_m_icon
     - field.field.media.civictheme_icon.field_c_m_media_tags
     - media.type.civictheme_icon
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - file

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_image.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_image.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.civictheme_image.field_c_m_media_tags
     - image.style.civictheme_medium
     - media.type.civictheme_image
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - focal_point

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_remote_video.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_remote_video.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.civictheme_remote_video.field_c_m_transcript
     - field.field.media.civictheme_remote_video.field_c_m_transcript_link
     - media.type.civictheme_remote_video
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - link

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_video.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.media.civictheme_video.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.civictheme_video.field_c_m_transcript_link
     - field.field.media.civictheme_video.field_c_m_video_file
     - media.type.civictheme_video
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - file

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_alert.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_alert.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.node.civictheme_alert.field_c_n_body
     - field.field.node.civictheme_alert.field_c_n_date_range
     - node.type.civictheme_alert
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - datetime_range

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_event.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_event.default.yml
@@ -15,7 +15,6 @@ dependencies:
     - field.field.node.civictheme_event.field_c_n_topics
     - field.field.node.civictheme_event.field_c_n_vertical_spacing
     - node.type.civictheme_event
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - datetime

--- a/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_page.default.yml
+++ b/web/themes/contrib/civictheme/config/install/core.entity_form_display.node.civictheme_page.default.yml
@@ -23,7 +23,6 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - node.type.civictheme_page
-    - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
     - datetime


### PR DESCRIPTION
When running the following command to clean up the configuration in GovCMS, the field widgets were removed.

`drush civictheme_govcms:remove-config --preserve=user_roles`

Tracked it down to the fact that we have the following dependency:

```
  config:
    - block_content.type.civictheme_component_block
    - field.field.block_content.civictheme_component_block.field_c_b_components
    - workflows.workflow.civictheme_editorial
```

In my testing, for some reason, `workflows.workflow.civictheme_editorial` was changed to `workflows.workflow.editorial` (which is the default workflow)

Then, when you run `drush civictheme_govcms:remove-config`, which removes the workflow, Drupal deletes all configurations that depend on the workflow.

Which is `core.entity_form_display.*.yml`

The fix for this is to remove the dependency from `core.entity_form_display.*.yml`.

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Remove workflow dependency from all config `core.entity_form_display.*.yml`

## Screenshots

![2025-06-02_20-52-55](https://github.com/user-attachments/assets/348a85a0-dd7c-42c2-8835-83462bd787cd)

