### PR TITLE
Issue #3501085 by richardgaunt, fionamorrison23, joshua1234511: Message - new paragraph component

### DIFF
--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -864,3 +864,77 @@ function civictheme_post_update_update_editor_allowed_field(): string {
   }
   return (string) new TranslatableMarkup('Allowed tags setting not set, aborting update.');
 }
+
+/**
+ * Add civictheme_message paragraph type and enable it for civictheme page.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_add_civictheme_message_paragraph(): string {
+  $new_configs = [
+    // Paragraph type definition.
+    'paragraphs.paragraphs_type.civictheme_message' => 'paragraphs_type',
+    'field.storage.paragraph.field_c_p_message_type' => 'field_storage_config',
+    'field.field.paragraph.civictheme_message.field_c_p_background' => 'field_config',
+    'field.field.paragraph.civictheme_message.field_c_p_content' => 'field_config',
+    'field.field.paragraph.civictheme_message.field_c_p_message_type' => 'field_config',
+    'field.field.paragraph.civictheme_message.field_c_p_theme' => 'field_config',
+    'field.field.paragraph.civictheme_message.field_c_p_title' => 'field_config',
+    'field.field.paragraph.civictheme_message.field_c_p_vertical_spacing' => 'field_config',
+    'core.entity_form_display.paragraph.civictheme_message.default' => 'entity_form_display',
+    'core.entity_view_display.paragraph.civictheme_message.default' => 'entity_view_display',
+  ];
+
+  $config_path = \Drupal::service('extension.list.theme')->getPath('civictheme') . '/config/install';
+  \Drupal::classResolver(CivicthemeUpdateHelper::class)->createConfigs($new_configs, $config_path);
+
+  // Enable civictheme_message for civictheme_page.
+  $field_config_name = 'field.field.node.civictheme_page.field_c_n_components';
+  $field_config = \Drupal::configFactory()->getEditable($field_config_name);
+
+  if (!$field_config->isNew()) {
+    $handler_settings = $field_config->get('settings.handler_settings') ?: [];
+    // Ensure target_bundles exists.
+    if (!isset($handler_settings['target_bundles'])) {
+      $handler_settings['target_bundles'] = [];
+    }
+    $handler_settings['target_bundles']['civictheme_message'] = 'civictheme_message';
+
+    // Ensure target_bundles_drag_drop exists.
+    if (!isset($handler_settings['target_bundles_drag_drop'])) {
+      $handler_settings['target_bundles_drag_drop'] = [];
+    }
+    $handler_settings['target_bundles_drag_drop']['civictheme_message'] = [
+      'weight' => -52,
+      'enabled' => TRUE,
+    ];
+
+    $field_config->set('settings.handler_settings', $handler_settings);
+    $field_config->save();
+  }
+
+  return (string) new TranslatableMarkup('Added civictheme_message paragraph type and enabled it for civictheme page.');
+}
+
+/**
+ * Update the field description for field_c_p_background.
+ */
+function civictheme_post_update_update_field_c_p_background_description(): string {
+  $field_configs = [
+    'field.field.paragraph.civictheme_accordion.field_c_p_background',
+    'field.field.paragraph.civictheme_content.field_c_p_background',
+    'field.field.paragraph.civictheme_map.field_c_p_background',
+    'field.field.paragraph.civictheme_promo.field_c_p_background',
+    'field.field.paragraph.civictheme_webform.field_c_p_background',
+  ];
+  foreach ($field_configs as $field_config_name) {
+    $field_config = \Drupal::configFactory()->getEditable($field_config_name);
+
+    if (!$field_config->isNew()) {
+      $field_config->set('description', 'Apply a themed background colour and provide horizontal spacing to the component');
+      $field_config->save();
+    }
+  }
+
+  return (string) new TranslatableMarkup('Updated field description for field_c_p_background.');
+}

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_accordion.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_accordion.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_accordion
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: true
 default_value:

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_content.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_content.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_content
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: false
 default_value:

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_map.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_map.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_map
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: true
 default_value:

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_message.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_message.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_message
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: false
 default_value:

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_promo.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_promo.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_promo
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: false
 default_value:

--- a/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_webform.field_c_p_background.yml
+++ b/web/themes/contrib/civictheme/config/install/field.field.paragraph.civictheme_webform.field_c_p_background.yml
@@ -9,7 +9,7 @@ field_name: field_c_p_background
 entity_type: paragraph
 bundle: civictheme_webform
 label: Background
-description: 'Apply a themed background color and provide horizontal spacing to the component'
+description: 'Apply a themed background colour and provide horizontal spacing to the component'
 required: false
 translatable: true
 default_value:


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3507328

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Update the help text so it is as per Australian/UK spelling `colour`.
2. Added a post update hook for new component.
3. Added post hook update so that other referces of `color` is fixed to use `colour`.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "CivicTheme Message" paragraph type, now available for use on CivicTheme pages.

* **Style**
  * Updated field descriptions to use British English spelling ("colour" instead of "color") for background colour options across various components.

* **Chores**
  * Improved clarity of background field descriptions for multiple CivicTheme paragraph types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->