### PR TITLE
By alex.skrypnyk: Fixed Shipshape installation requiring an access token.

### DIFF
--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -49,6 +49,10 @@ RUN apk update \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 
+RUN curl -L -o shipshape "https://github.com/salsadigitalauorg/shipshape/releases/download/v0.3.1/shipshape-$(uname -s)-$(uname -m)" && \
+    chmod +x shipshape && \
+    mv shipshape /usr/local/bin/shipshape
+
 # Install updated version of NPM.
 RUN npm install -g npm@^8.6 && fix-permissions /home/.npm
 
@@ -62,9 +66,6 @@ RUN mkdir -p web/themes/contrib/civictheme \
     && mkdir -p web/modules/custom/civictheme_content \
     && mkdir -p web/modules/custom/civictheme_dev \
     && mkdir -p web/modules/custom/cs_generated_content
-
-# Add shipshape binary so that we can execute audits.
-COPY --from=ghcr.io/salsadigitalauorg/shipshape:latest /usr/local/bin/shipshape /usr/local/bin/shipshape
 
 # Copy files required for PHP dependencies resolution.
 # Note that composer.lock is not explicitly copied, allowing to run the stack

--- a/.docker/cli.onlytheme.dockerfile
+++ b/.docker/cli.onlytheme.dockerfile
@@ -48,6 +48,10 @@ RUN apk update \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 
+RUN curl -L -o shipshape "https://github.com/salsadigitalauorg/shipshape/releases/download/v0.3.1/shipshape-$(uname -s)-$(uname -m)" && \
+    chmod +x shipshape && \
+    mv shipshape /usr/local/bin/shipshape
+
 # Install updated version of NPM.
 RUN npm install -g npm@^8.6 && fix-permissions /home/.npm
 
@@ -61,9 +65,6 @@ RUN mkdir -p web/themes/contrib/civictheme \
     && mkdir -p web/modules/custom/civictheme_content \
     && mkdir -p web/modules/custom/civictheme_dev \
     && mkdir -p web/modules/custom/cs_generated_content
-
-# Add shipshape binary so that we can execute audits.
-COPY --from=ghcr.io/salsadigitalauorg/shipshape:latest /usr/local/bin/shipshape /usr/local/bin/shipshape
 
 # Copy files required for PHP dependencies resolution.
 # Note that composer.lock is not explicitly copied, allowing to run the stack

--- a/.docker/cli.sibling.dockerfile
+++ b/.docker/cli.sibling.dockerfile
@@ -49,6 +49,10 @@ RUN apk update \
     && ln -sf python3 /usr/bin/python \
     && rm -rf /var/cache/apk/*
 
+RUN curl -L -o shipshape "https://github.com/salsadigitalauorg/shipshape/releases/download/v0.3.1/shipshape-$(uname -s)-$(uname -m)" && \
+    chmod +x shipshape && \
+    mv shipshape /usr/local/bin/shipshape
+
 # Install updated version of NPM.
 RUN npm install -g npm@^8.6 && fix-permissions /home/.npm
 
@@ -62,9 +66,6 @@ RUN mkdir -p web/themes/contrib/civictheme \
     && mkdir -p web/modules/custom/civictheme_content \
     && mkdir -p web/modules/custom/civictheme_dev \
     && mkdir -p web/modules/custom/cs_generated_content
-
-# Add shipshape binary so that we can execute audits.
-COPY --from=ghcr.io/salsadigitalauorg/shipshape:latest /usr/local/bin/shipshape /usr/local/bin/shipshape
 
 # Copy files required for PHP dependencies resolution.
 # Note that composer.lock is not explicitly copied, allowing to run the stack


### PR DESCRIPTION
A change in this PR updates the installation of Shipshape to take place earlier in the image as this is a standalone library. A standard practice is to install a binary from the distribution archives rather than from the Docker images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI Docker images now install Shipshape at build time from a fixed upstream release (v0.3.1) rather than sourcing it from an external image.
  * Change applied consistently across all CLI variants.
  * Other build steps remain unchanged; runtime behavior and public interfaces are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->