### PR TITLE
By alex.skrypnyk: Relax Stylelint rules to allow local SCSS variables in sub-themes.

### DIFF
--- a/web/themes/contrib/civictheme/civictheme_starter_kit/.stylelintrc.json
+++ b/web/themes/contrib/civictheme/civictheme_starter_kit/.stylelintrc.json
@@ -43,7 +43,7 @@
     "scss/at-if-no-null": null,
     "scss/comment-no-empty": null,
     "scss/comment-no-loud": true,
-    "scss/dollar-variable-pattern": ["^(root|_?ct-.+)", {"ignore": "local"}],
+    "scss/dollar-variable-pattern": ["^(root|_.+|ct-.+)$", {"ignore": "local"}],
     "scss/at-function-parentheses-space-before": "never",
     "selector-class-pattern": null,
     "string-quotes": "single"


### PR DESCRIPTION
Currently, sub-themes scaffolded from the starter kit are not allowed to have local SCSS variables named `root` or starting with `ct-` or `_ct-`.

This PR relaxes these rules to allow having local variables starting with underscore `_`.

Note that `local` variables in the Stylelint rule are the variables scoped by functions and mixins, but not the variables appearing within the rule, so ` {"ignore": "local"}` does not apply here.

I.e.,

```scss

@mixin mymixin(){
  $abc: 123; // <-- 'local' variable (from Stylelint's POV)
}

.my-component {
  $abc: 123;  // <-- not a 'local' variable (from Stylelint's POV)
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated stylelint rules for SCSS variable names to broaden allowed patterns and enforce full-string matching. Underscore-prefixed variables are now permitted alongside existing root and ct- prefixed names, while local variables remain ignored. This improves consistency and reduces lint noise for developers without affecting runtime behavior or user-facing styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->