### PR TITLE
Issue #3542546 by alex.skrypnyk: Apply TOC and tags only to the full view mode of Page

### DIFF
--- a/web/themes/contrib/civictheme/includes/node.inc
+++ b/web/themes/contrib/civictheme/includes/node.inc
@@ -24,12 +24,20 @@ function _civictheme_preprocess_node(array &$variables): void {
   if (!$node->isPublished()) {
     $variables['attributes']['class'][] = 'node--unpublished';
   }
+}
 
-  $view_mode = $variables['elements']['#view_mode'];
-  // Do not display node title on revision pages.
-  if ($view_mode === 'full') {
-    unset($variables['label']);
+/**
+ * Pre-process CivicTheme page nodes.
+ */
+function _civictheme_preprocess_node__civictheme_page__full(array &$variables): void {
+  $node = $variables['node'];
+
+  if (!$node) {
+    return;
   }
+
+  // Do not display node title on revision pages.
+  unset($variables['label']);
 
   // Add Table of Contents if the value is set on node.
   if (civictheme_get_field_value($node, 'field_c_n_show_toc')) {


### PR DESCRIPTION
https://www.drupal.org/project/civictheme/issues/3542546

## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `Issue #123456 by drupal_org_username: Issue title`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Moved TOC and Tags code to the view mode-specific preprocess function.