### PR TITLE
[#3543470] Updated provision callbacks to provide the theme_name to apply provisioning to.

### DIFF
--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -128,13 +128,13 @@ function _civictheme_form_system_theme_settings_provision_validate(array &$form,
 function _civictheme_form_system_theme_settings_provision_submit(array &$form, FormStateInterface $form_state): void {
   $triggering_element = $form_state->getTriggeringElement();
   $button_name = $triggering_element['#name'] ?? '';
-
+  $theme_name = explode('.', $form_state->getValues()['config_key'])[0];
   if ($button_name === 'provision') {
     $types = array_filter($form_state->getValue('provision_types'));
     $clear_cache = $form_state->getValue('provision_clear_cache');
 
     if (!empty($types)) {
-      $results = civictheme_provision($types, $clear_cache);
+      $results = civictheme_provision($theme_name, $types, $clear_cache);
 
       foreach ($results as $type => $result) {
         if ($result === TRUE) {
@@ -171,6 +171,8 @@ function _civictheme_form_system_theme_settings_provision_submit(array &$form, F
 /**
  * Provision content.
  *
+ * @param string $theme_name
+ *   The theme to provision the block and other theme specific entities to.
  * @param array $types
  *   Optional array of types discovered from defined callbacks.
  *   If not provided - provisioning for all types will run.
@@ -190,7 +192,7 @@ function _civictheme_form_system_theme_settings_provision_submit(array &$form, F
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.MissingImport)
  */
-function civictheme_provision(array $types = [], $clear_cache = TRUE, bool $verbose = FALSE): array {
+function civictheme_provision(string $theme_name, array $types = [], $clear_cache = TRUE, bool $verbose = FALSE): array {
   $results = [];
 
   $callbacks = _civictheme_provision_discover_callbacks();
@@ -212,7 +214,7 @@ function civictheme_provision(array $types = [], $clear_cache = TRUE, bool $verb
       try {
         $results[$callback_type] = FALSE;
         // @phpstan-ignore-next-line
-        $return = call_user_func($callbacks[$callback_type]);
+        $return = call_user_func($callbacks[$callback_type], $theme_name);
         // Allow callbacks to not return a value on success.
         // Failure can be returned as FALSE or exception.
         if ($return === TRUE || is_null($return)) {
@@ -264,8 +266,8 @@ function civictheme_provision_cli(array $include_types = [], array $exclude_type
   if (!empty($exclude_types)) {
     $types = array_diff($types, $exclude_types);
   }
-
-  $results = civictheme_provision($types, TRUE, TRUE);
+  $theme_name = \Drupal::service('theme_handler')->getDefault();
+  $results = civictheme_provision($theme_name, $types, TRUE, TRUE);
   $errors = array_filter($results, static function ($value): bool {
     return $value !== TRUE;
   });
@@ -428,14 +430,14 @@ function civictheme_provision_create_block_content($block_type, $info, $uuid): B
  * @param array $settings
  *   Optional array of settings to pass to the block. Default to empty array.
  *   If not provided - sensible defaults will be used.
+ * @param string $theme_name
+ *   The theme to place the block on.
  * @param string $block_type
  *   Optional block type. Defaults to 'block_content'.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function civictheme_provision_place_block(string $label, string $region, ?string $uuid = NULL, array $settings = [], string $block_type = 'block_content'): void {
-  $theme_name = \Drupal::configFactory()->get('system.theme')->get('default');
-
+function civictheme_provision_place_block(string $label, string $region, ?string $uuid = NULL, array $settings = [], string $theme_name, string $block_type = 'block_content'): void {
   $label_machine_name = $settings['label_machine_name'] ?? preg_replace('@[^a-zA-Z0-9_]+@', '_', strtolower(str_replace(' ', '_', $label)));
   $id = $theme_name . '_' . $label_machine_name;
   $base_theme_id = 'civictheme_' . $label_machine_name;
@@ -551,11 +553,13 @@ function civictheme_provision_clear_menu(string $menu_name): void {
 /**
  * Provision files.
  *
+ * @param string $theme_name
+ *   Theme to apply provisioning to.
+ *
  * @SuppressWarnings(PHPMD.StaticAccess)
  * @SuppressWarnings(PHPMD.MissingImport)
  */
-function civictheme_provision__files(): void {
-  $theme_name = \Drupal::config('system.theme')->get('default');
+function civictheme_provision__files(string $theme_name): void {
   $theme_path = \Drupal::service('extension.list.theme')->getPath($theme_name);
 
   $filepaths = [
@@ -582,11 +586,13 @@ function civictheme_provision__files(): void {
 /**
  * Provision media.
  *
+ * @param string $theme_name
+ *   Theme to apply provisioning to.
+ *
  * @SuppressWarnings(PHPMD.StaticAccess)
  * @SuppressWarnings(PHPMD.MissingImport)
  */
-function civictheme_provision__media(): void {
-  $theme_name = \Drupal::config('system.theme')->get('default');
+function civictheme_provision__media(string $theme_name): void {
 
   $filenames_for_media = [
     'icon' => [
@@ -673,26 +679,29 @@ function civictheme_provision__menu_links(): void {
 
 /**
  * Provision blocks.
+ *
+ * @param string $theme_name
+ *   The theme to provision blocks for.
  */
-function civictheme_provision__blocks(): void {
-  _civictheme_provision__blocks__menu_blocks();
+function civictheme_provision__blocks(string $theme_name): void {
+  _civictheme_provision__blocks__menu_blocks($theme_name);
   $blocks = _civictheme_get_theme_blocks();
   foreach ($blocks as $block) {
-    call_user_func($block['builder'], $block);
+    call_user_func($block['builder'], $block, $theme_name);
   }
 }
 
 /**
  * Provision menu blocks.
  */
-function _civictheme_provision__blocks__menu_blocks(): void {
+function _civictheme_provision__blocks__menu_blocks(string $theme_name): void {
   civictheme_provision_place_block('Primary Navigation', 'header_middle_3', NULL, [
     'plugin' => 'menu_block:civictheme-primary-navigation',
     'depth' => 3,
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Secondary Navigation', 'header_top_3', NULL, [
     'plugin' => 'menu_block:civictheme-secondary-navigation',
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Side Navigation', 'sidebar_top_left', NULL, [
     'plugin' => 'menu_block:civictheme-primary-navigation',
     'depth' => 3,
@@ -704,23 +713,23 @@ function _civictheme_provision__blocks__menu_blocks(): void {
       ],
     ],
     'suggestion' => 'civictheme_sidebar_navigation',
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Footer menu 1', 'footer_middle_1', NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Footer menu 2', 'footer_middle_2', NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Footer menu 3', 'footer_middle_3', NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ]);
+  ], $theme_name);
   civictheme_provision_place_block('Footer menu 4', 'footer_middle_4', NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ]);
+  ], $theme_name);
 }
 
 /**
@@ -728,9 +737,10 @@ function _civictheme_provision__blocks__menu_blocks(): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  */
-function _civictheme_provision__blocks__banner(array $block): void {
-  $theme_name = \Drupal::config('system.theme')->get('default');
+function _civictheme_provision__blocks__banner(array $block, string $theme_name): void {
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
   $block_content->set('field_c_b_background_image', civictheme_provision_load_media_by_name($theme_name . '_background_1.png'));
   $block_content->set('field_c_b_theme', 'dark');
@@ -738,7 +748,7 @@ function _civictheme_provision__blocks__banner(array $block): void {
   $block_content->set('field_c_b_banner_type', 'default');
   $block_content->set('field_c_b_featured_image', civictheme_provision_load_media_by_name('demo_image.jpg'));
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid());
+  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
 }
 
 /**
@@ -746,10 +756,12 @@ function _civictheme_provision__blocks__banner(array $block): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_provision__blocks__search(array $block): void {
+function _civictheme_provision__blocks__search(array $block, string $theme_name): void {
   // Redirect to 'Search' page if the path exists.
   $search_path = '/search';
   $fallback_path = '/';
@@ -770,7 +782,7 @@ function _civictheme_provision__blocks__search(array $block): void {
     'uri' => $search_path,
   ]);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid());
+  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
 }
 
 /**
@@ -778,9 +790,10 @@ function _civictheme_provision__blocks__search(array $block): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  */
-function _civictheme_provision__blocks__mobile_navigation(array $block): void {
-  $theme_name = \Drupal::config('system.theme')->get('default');
+function _civictheme_provision__blocks__mobile_navigation(array $block, string $theme_name): void {
 
   $context_theme = \Drupal::service('class_resolver')->getInstanceFromDefinition(CivicthemeConfigManager::class)->load('components.header.theme', CivicthemeConstants::HEADER_THEME_DEFAULT);
 
@@ -790,7 +803,7 @@ function _civictheme_provision__blocks__mobile_navigation(array $block): void {
   $block_content->set('field_c_b_trigger_text', 'Menu');
   $block_content->set('field_c_b_trigger_theme', $context_theme);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid());
+  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
 }
 
 /**
@@ -798,10 +811,12 @@ function _civictheme_provision__blocks__mobile_navigation(array $block): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_provision__blocks__signup(array $block): void {
+function _civictheme_provision__blocks__signup(array $block, $theme_name): void {
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
   $paragraph = Paragraph::create([
     'type' => 'civictheme_promo',
@@ -819,7 +834,7 @@ function _civictheme_provision__blocks__signup(array $block): void {
   $paragraph->set('field_c_p_vertical_spacing', CivicthemeConstants::VERTICAL_SPACING_TOP);
   $block_content->get('field_c_b_components')->appendItem($paragraph);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid());
+  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
 }
 
 /**
@@ -827,10 +842,12 @@ function _civictheme_provision__blocks__signup(array $block): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_provision__blocks__social_links(array $block): void {
+function _civictheme_provision__blocks__social_links(array $block, $theme_name): void {
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
 
   $paragraph = Paragraph::create([
@@ -868,7 +885,7 @@ function _civictheme_provision__blocks__social_links(array $block): void {
   $block_content->save();
   civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
     'label_machine_name' => 'footer_social_links',
-  ]);
+  ], $theme_name);
 }
 
 /**
@@ -876,10 +893,12 @@ function _civictheme_provision__blocks__social_links(array $block): void {
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_provision__blocks__acknowledgment_of_country(array $block): void {
+function _civictheme_provision__blocks__acknowledgment_of_country(array $block, string $theme_name): void {
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
   $paragraph = Paragraph::create([
     'type' => 'civictheme_content',
@@ -893,7 +912,7 @@ function _civictheme_provision__blocks__acknowledgment_of_country(array $block):
   $block_content->save();
   civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
     'label_machine_name' => 'footer_acknowledgment_of_country',
-  ]);
+  ], $theme_name);
 }
 
 /**
@@ -901,10 +920,12 @@ function _civictheme_provision__blocks__acknowledgment_of_country(array $block):
  *
  * @param array $block
  *   Data structure of block.
+ * @param string $theme_name
+ *   Theme to apply this block to.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function _civictheme_provision__blocks__copyright(array $block): void {
+function _civictheme_provision__blocks__copyright(array $block, $theme_name): void {
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
   $paragraph = Paragraph::create([
     'type' => 'civictheme_content',
@@ -918,16 +939,18 @@ function _civictheme_provision__blocks__copyright(array $block): void {
   $block_content->save();
   civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
     'label_machine_name' => 'footer_copyright',
-  ]);
+  ], $theme_name);
 }
 
 /**
  * Provision theme settings.
  *
+ * @param string $theme_name
+ *   Theme to apply settings to.
+ *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function civictheme_provision__theme_settings(): void {
-  $theme_name = \Drupal::config('system.theme')->get('default');
+function civictheme_provision__theme_settings(string $theme_name): void {
   $theme_path = \Drupal::service('extension.list.theme')->getPath($theme_name);
 
   /** @var \Drupal\civictheme\CivicthemeConfigImporter $config_importer */

--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -910,7 +910,7 @@ function _civictheme_provision__blocks__acknowledgment_of_country(array $block, 
   $block_content->save();
   civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), [
     'label_machine_name' => 'footer_acknowledgment_of_country',
-  ], $theme_name);
+  ]);
 }
 
 /**

--- a/web/themes/contrib/civictheme/theme-settings.provision.inc
+++ b/web/themes/contrib/civictheme/theme-settings.provision.inc
@@ -424,20 +424,20 @@ function civictheme_provision_create_block_content($block_type, $info, $uuid): B
  *   Admin label for the block.
  * @param string $region
  *   Region to place the block into.
+ * @param string $theme_name
+ *   The theme to place the block on.
  * @param string $uuid
  *   Optional UUID to use for plugin_id. Defaults to NULL. If not provided - a
  *   random UUID will be generated.
  * @param array $settings
  *   Optional array of settings to pass to the block. Default to empty array.
  *   If not provided - sensible defaults will be used.
- * @param string $theme_name
- *   The theme to place the block on.
  * @param string $block_type
  *   Optional block type. Defaults to 'block_content'.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-function civictheme_provision_place_block(string $label, string $region, ?string $uuid = NULL, array $settings = [], string $theme_name, string $block_type = 'block_content'): void {
+function civictheme_provision_place_block(string $label, string $region, string $theme_name, ?string $uuid = NULL, array $settings = [], string $block_type = 'block_content'): void {
   $label_machine_name = $settings['label_machine_name'] ?? preg_replace('@[^a-zA-Z0-9_]+@', '_', strtolower(str_replace(' ', '_', $label)));
   $id = $theme_name . '_' . $label_machine_name;
   $base_theme_id = 'civictheme_' . $label_machine_name;
@@ -593,7 +593,6 @@ function civictheme_provision__files(string $theme_name): void {
  * @SuppressWarnings(PHPMD.MissingImport)
  */
 function civictheme_provision__media(string $theme_name): void {
-
   $filenames_for_media = [
     'icon' => [
       'facebook.svg',
@@ -695,14 +694,14 @@ function civictheme_provision__blocks(string $theme_name): void {
  * Provision menu blocks.
  */
 function _civictheme_provision__blocks__menu_blocks(string $theme_name): void {
-  civictheme_provision_place_block('Primary Navigation', 'header_middle_3', NULL, [
+  civictheme_provision_place_block('Primary Navigation', 'header_middle_3', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-primary-navigation',
     'depth' => 3,
-  ], $theme_name);
-  civictheme_provision_place_block('Secondary Navigation', 'header_top_3', NULL, [
+  ],);
+  civictheme_provision_place_block('Secondary Navigation', 'header_top_3', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-secondary-navigation',
-  ], $theme_name);
-  civictheme_provision_place_block('Side Navigation', 'sidebar_top_left', NULL, [
+  ]);
+  civictheme_provision_place_block('Side Navigation', 'sidebar_top_left', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-primary-navigation',
     'depth' => 3,
     'visibility' => [
@@ -714,22 +713,22 @@ function _civictheme_provision__blocks__menu_blocks(string $theme_name): void {
     ],
     'suggestion' => 'civictheme_sidebar_navigation',
   ], $theme_name);
-  civictheme_provision_place_block('Footer menu 1', 'footer_middle_1', NULL, [
+  civictheme_provision_place_block('Footer menu 1', 'footer_middle_1', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ], $theme_name);
-  civictheme_provision_place_block('Footer menu 2', 'footer_middle_2', NULL, [
+  ]);
+  civictheme_provision_place_block('Footer menu 2', 'footer_middle_2', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ], $theme_name);
-  civictheme_provision_place_block('Footer menu 3', 'footer_middle_3', NULL, [
+  ]);
+  civictheme_provision_place_block('Footer menu 3', 'footer_middle_3', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ], $theme_name);
-  civictheme_provision_place_block('Footer menu 4', 'footer_middle_4', NULL, [
+  ]);
+  civictheme_provision_place_block('Footer menu 4', 'footer_middle_4', $theme_name, NULL, [
     'plugin' => 'menu_block:civictheme-footer',
     'depth' => 1,
-  ], $theme_name);
+  ]);
 }
 
 /**
@@ -748,7 +747,7 @@ function _civictheme_provision__blocks__banner(array $block, string $theme_name)
   $block_content->set('field_c_b_banner_type', 'default');
   $block_content->set('field_c_b_featured_image', civictheme_provision_load_media_by_name('demo_image.jpg'));
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), []);
 }
 
 /**
@@ -782,7 +781,7 @@ function _civictheme_provision__blocks__search(array $block, string $theme_name)
     'uri' => $search_path,
   ]);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), []);
 }
 
 /**
@@ -794,7 +793,6 @@ function _civictheme_provision__blocks__search(array $block, string $theme_name)
  *   Theme to apply this block to.
  */
 function _civictheme_provision__blocks__mobile_navigation(array $block, string $theme_name): void {
-
   $context_theme = \Drupal::service('class_resolver')->getInstanceFromDefinition(CivicthemeConfigManager::class)->load('components.header.theme', CivicthemeConstants::HEADER_THEME_DEFAULT);
 
   $block_content = civictheme_provision_create_block_content($block['type'], $block['name'], $block['uuid']);
@@ -803,7 +801,7 @@ function _civictheme_provision__blocks__mobile_navigation(array $block, string $
   $block_content->set('field_c_b_trigger_text', 'Menu');
   $block_content->set('field_c_b_trigger_theme', $context_theme);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), []);
 }
 
 /**
@@ -834,7 +832,7 @@ function _civictheme_provision__blocks__signup(array $block, $theme_name): void 
   $paragraph->set('field_c_p_vertical_spacing', CivicthemeConstants::VERTICAL_SPACING_TOP);
   $block_content->get('field_c_b_components')->appendItem($paragraph);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [], $theme_name);
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), []);
 }
 
 /**
@@ -883,9 +881,9 @@ function _civictheme_provision__blocks__social_links(array $block, $theme_name):
   $block_content->set('field_c_b_theme', CivicthemeConstants::THEME_DARK);
   $block_content->set('field_c_b_with_border', TRUE);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), [
     'label_machine_name' => 'footer_social_links',
-  ], $theme_name);
+  ]);
 }
 
 /**
@@ -910,7 +908,7 @@ function _civictheme_provision__blocks__acknowledgment_of_country(array $block, 
   $paragraph->set('field_c_p_theme', CivicthemeConstants::THEME_DARK);
   $block_content->get('field_c_b_components')->appendItem($paragraph);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), [
     'label_machine_name' => 'footer_acknowledgment_of_country',
   ], $theme_name);
 }
@@ -937,9 +935,9 @@ function _civictheme_provision__blocks__copyright(array $block, $theme_name): vo
   $paragraph->set('field_c_p_theme', CivicthemeConstants::THEME_DARK);
   $block_content->get('field_c_b_components')->appendItem($paragraph);
   $block_content->save();
-  civictheme_provision_place_block($block['name'], $block['region'], $block_content->uuid(), [
+  civictheme_provision_place_block($block['name'], $block['region'], $theme_name, $block_content->uuid(), [
     'label_machine_name' => 'footer_copyright',
-  ], $theme_name);
+  ]);
 }
 
 /**


### PR DESCRIPTION
## JIRA ticket: #3543470

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as 
- [x] I have added a link to the issue tracker
- [x] I have provided information in  section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed
1. [#3543470] Content provisioned from theme settings applies to the theme selected in theme settings.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Provisioning now explicitly targets a selected theme across UI and CLI, applying files, media, blocks, and theme settings per theme.
  - Block placement and builders are theme-aware for common components (banner, search, mobile navigation, signup, social links, acknowledgments, copyright).
- Bug Fixes
  - Prevents assets or configurations from being applied to the wrong theme; improves messaging and cache handling during provisioning.
- Refactor
  - Standardized provisioning flow around an explicit theme context for more reliable, consistent provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->