### PR TITLE
Fix link to theme docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ detailed information on setting up your local development environment.
 
 Before starting, ensure you have reviewed the documentation for
 [UI kit](https://docs.civictheme.io/ui-kit) and
-[Drupal theme](https://docs.civictheme.io/drupal-theme).
+[Drupal theme](https://docs.civictheme.io/development/drupal-theme).
 
 
 ## Build types


### PR DESCRIPTION
## Changed

1. The link was broken; now it is not.  Maybe there should be a redirect also if that is possible as i expect it used to be right, but that is outside the scope of this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Drupal theme documentation link to point to the development section, ensuring users land on current guidance.
  * Clarifies where to find theme setup and customization instructions, improving navigation consistency and reducing contributor confusion.
  * No changes to user-facing behavior, APIs, build, or runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->