### PR TITLE
Issue #3620794 by ivrh: Remove alert REST export result limit

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,3 +64,10 @@ To update the database dumps:
    mkdir -p web/themes/contrib/civictheme/tests/fixtures/updates
    ahoy cli php web/core/scripts/dump-database-d8-mysql.php | gzip > "web/themes/contrib/civictheme/tests/fixtures/updates/drupal_${DRUPAL_VERSION_FULL}.${DRUPAL_PROFILE}.civictheme_${CIVICTHEME_VERSION}.filled.php.gz"
    ```
+
+### Alert REST export
+
+The alert REST display must return all active alerts before the browser applies
+page visibility rules. When checking this behaviour, create more than 10 active
+alerts targeting different pages and verify that every eligible alert is present
+in `/api/civictheme-alerts`, including alerts outside the first 10 results.

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -1357,3 +1357,24 @@ function civictheme_post_update_add_fast_fact_card_form_display(): string {
 
   return (string) new TranslatableMarkup('Created form display for civictheme_fast_fact_card paragraph.');
 }
+
+/**
+ * Return all active alerts before client-side page visibility matching.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_remove_alert_export_limit(): string {
+  $config = \Drupal::configFactory()->getEditable('views.view.civictheme_alerts');
+  $display_path = 'display.rest_export_civictheme_alerts';
+  if ($config->isNew() || $config->get($display_path . '.display_plugin') !== 'rest_export') {
+    return (string) new TranslatableMarkup('Alert export pager update skipped: REST display does not exist.');
+  }
+
+  // REST exports need an explicit pager; changing the default is insufficient.
+  $config->set($display_path . '.display_options.pager', [
+    'type' => 'none',
+    'options' => ['offset' => 0],
+  ])->save();
+
+  return (string) new TranslatableMarkup('Updated the alert REST export to return all active alerts.');
+}

--- a/web/themes/contrib/civictheme/config/install/views.view.civictheme_alerts.yml
+++ b/web/themes/contrib/civictheme/config/install/views.view.civictheme_alerts.yml
@@ -459,6 +459,10 @@ display:
     display_plugin: rest_export
     position: 1
     display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
       style:
         type: serializer
         options:

--- a/web/themes/contrib/civictheme/tests/src/Unit/CivicthemeAlertPagerUpdateTest.php
+++ b/web/themes/contrib/civictheme/tests/src/Unit/CivicthemeAlertPagerUpdateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\civictheme\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests the alert REST pager update without changing other view settings.
+ *
+ * @group CivicTheme
+ */
+class CivicthemeAlertPagerUpdateTest extends UnitTestCase {
+
+  /**
+   * Tests existing views and repeat execution of the update.
+   */
+  public function testExistingView(): void {
+    $data = Yaml::parseFile(__DIR__ . '/../../../config/install/views.view.civictheme_alerts.yml');
+    // Simulate the previous release, where REST defaults to a limited pager.
+    unset($data['display']['rest_export_civictheme_alerts']['display_options']['pager']);
+    $expected = $data;
+    $expected['display']['rest_export_civictheme_alerts']['display_options']['pager'] = [
+      'type' => 'none',
+      'options' => ['offset' => 0],
+    ];
+    $config = $this->prepareConfig($data);
+    $config->expects($this->exactly(2))->method('save')->willReturnSelf();
+
+    civictheme_post_update_remove_alert_export_limit();
+    $this->assertSame($expected, $config->getRawData());
+    civictheme_post_update_remove_alert_export_limit();
+    $this->assertSame($expected, $config->getRawData());
+  }
+
+  /**
+   * Tests that a removed REST display is not recreated.
+   */
+  public function testMissingDisplay(): void {
+    $data = ['display' => ['default' => ['display_plugin' => 'default']]];
+    $config = $this->prepareConfig($data);
+    $config->expects($this->never())->method('save');
+    civictheme_post_update_remove_alert_export_limit();
+    $this->assertSame($data, $config->getRawData());
+  }
+
+  /**
+   * Tests that an absent view is not created.
+   */
+  public function testMissingView(): void {
+    $config = $this->prepareConfig([], TRUE);
+    $config->expects($this->never())->method('save');
+    civictheme_post_update_remove_alert_export_limit();
+    $this->assertSame([], $config->getRawData());
+  }
+
+  /**
+   * Prepares real config data access with persistence mocked out.
+   */
+  protected function prepareConfig(array $data, bool $is_new = FALSE): Config {
+    require_once __DIR__ . '/../../../civictheme.post_update.php';
+    $config = $this->getMockBuilder(Config::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['save', 'isNew'])
+      ->getMock();
+    $config->setData($data);
+    $config->method('isNew')->willReturn($is_new);
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('getEditable')->with('views.view.civictheme_alerts')->willReturn($config);
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $factory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    \Drupal::setContainer($container);
+    return $config;
+  }
+
+}


### PR DESCRIPTION
Issue: https://www.drupal.org/project/civictheme/issues/3620794

## Checklist before requesting a review

- [x] I have formatted the subject to include the Drupal.org issue number and username.
- [x] I have added a link to the issue tracker.
- [x] I have explained why the change is needed.
- [x] I have performed a self-review of my code.
- [x] I have commented the non-obvious REST pager behaviour.
- [x] I have added regression tests.
- [x] I have run new and existing relevant tests locally, and they passed.
- [x] Screenshots are not applicable.

## Changed

The alert endpoint returns only 10 records before the browser applies page visibility rules. A site with more than 10 active alerts targeting different pages can therefore silently lose an alert even when it is the only one intended for that page. This is a limit on the exported dataset, not on the number shown per page.

Set the REST display's pager explicitly to `none`, with offset zero. Changing the default display alone does not override the REST display's effective `some` pager. A post-update applies this to existing alert REST displays and skips deleted views/displays. This also replaces a custom pager on that specific REST display; all eligible alerts must reach client-side matching. Other view settings, including content filters, remain intact.

The unit tests cover the update, repeat execution, preserving other settings, and missing views/displays. All 310 tests in the existing unit suite pass (with existing deprecation notices). A separate in-memory Drupal Views execution confirmed 14 active results after the change versus 10 before it; no content or active configuration was saved during that check. The full site/Behat suites were not run.

The visibility encoding fix is submitted separately under the same Drupal.org issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert REST exports now return all active, eligible alerts instead of limiting results to the first 10.
  * Existing installations are updated automatically to apply the expanded export behavior.

* **Documentation**
  * Added testing guidance for verifying REST exports with more than 10 alerts.

* **Tests**
  * Added coverage for applying the update safely, repeatedly, and without recreating missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->