### PR TITLE
Issue #3620794 by ivrh: Export raw alert visibility paths

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,13 @@ Behat configuration uses multiple extensions:
 
 Add `@skipped` tag to failing tests if you would like to skip them.
 
+### Alert REST export regression checks
+
+When changing the alert REST export, test visibility values with multiple lines,
+literal `<front>`, and ampersands. Also test an empty visibility value. The
+visibility field must use raw output so these path values reach the client
+without HTML escaping or markup.
+
 ### Authoring schema update tests
 
 > Available from CivicTheme 1.5

--- a/web/themes/contrib/civictheme/civictheme.post_update.php
+++ b/web/themes/contrib/civictheme/civictheme.post_update.php
@@ -798,6 +798,35 @@ function civictheme_post_update_alert_visibility_validation(): string {
 }
 
 /**
+ * Use raw alert visibility field values in the REST export.
+ *
+ * The raw values preserve path aliases containing HTML-sensitive characters,
+ * including <front> and ampersands.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+function civictheme_post_update_alert_visibility_raw_output(): string {
+  $config_name = 'views.view.civictheme_alerts';
+  $field_options_path = 'display.rest_export_civictheme_alerts.display_options.row.options.field_options';
+  $raw_output_path = $field_options_path . '.field_c_n_alert_page_visibility.raw_output';
+  $config_object = \Drupal::configFactory()->getEditable($config_name);
+  $field_options = $config_object->get($field_options_path);
+
+  if (!is_array($field_options) || !array_key_exists('field_c_n_alert_page_visibility', $field_options)) {
+    return (string) new TranslatableMarkup('Update to alert REST export skipped because the visibility field does not exist.');
+  }
+
+  if ($config_object->get($raw_output_path) === TRUE) {
+    return (string) new TranslatableMarkup('Alert REST export already uses raw visibility field values.');
+  }
+
+  $config_object->set($raw_output_path, TRUE);
+  $config_object->save();
+
+  return (string) new TranslatableMarkup('Updated alert REST export to use raw visibility field values.');
+}
+
+/**
  * Update the view mode 'civictheme_snippet' to 'civictheme_navigation_card'.
  *
  * @SuppressWarnings(PHPMD.StaticAccess)

--- a/web/themes/contrib/civictheme/config/install/views.view.civictheme_alerts.yml
+++ b/web/themes/contrib/civictheme/config/install/views.view.civictheme_alerts.yml
@@ -477,7 +477,7 @@ display:
               raw_output: false
             field_c_n_alert_page_visibility:
               alias: visibility
-              raw_output: false
+              raw_output: true
       display_comment: ''
       display_extenders: {  }
       path: api/civictheme-alerts

--- a/web/themes/contrib/civictheme/tests/src/Kernel/CivicthemeAlertVisibilityUpdateKernelTest.php
+++ b/web/themes/contrib/civictheme/tests/src/Kernel/CivicthemeAlertVisibilityUpdateKernelTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\civictheme\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the alert REST export visibility post-update.
+ *
+ * @group CivicTheme
+ * @group site:kernel
+ */
+class CivicthemeAlertVisibilityUpdateKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'serialization', 'rest', 'views'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $configSchemaCheckerExclusions = ['views.view.civictheme_alerts'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once __DIR__ . '/../../../civictheme.post_update.php';
+  }
+
+  /**
+   * Tests the post-update preserves the rest of the REST export configuration.
+   */
+  public function testRawOutputIsEnabledAndIdempotent(): void {
+    $config = $this->config('views.view.civictheme_alerts');
+    $config->set('display.rest_export_civictheme_alerts.display_options.row.options.field_options', [
+      'rendered_entity' => [
+        'alias' => 'message',
+        'raw_output' => FALSE,
+      ],
+      'field_c_n_alert_page_visibility' => [
+        'alias' => 'visibility',
+        'raw_output' => FALSE,
+      ],
+    ])->save();
+
+    $message = civictheme_post_update_alert_visibility_raw_output();
+
+    $this->assertStringContainsString('Updated alert REST export', $message);
+    $this->assertTrue($this->config('views.view.civictheme_alerts')->get('display.rest_export_civictheme_alerts.display_options.row.options.field_options.field_c_n_alert_page_visibility.raw_output'));
+    $this->assertFalse($this->config('views.view.civictheme_alerts')->get('display.rest_export_civictheme_alerts.display_options.row.options.field_options.rendered_entity.raw_output'));
+
+    $message = civictheme_post_update_alert_visibility_raw_output();
+
+    $this->assertStringContainsString('already uses raw visibility', $message);
+  }
+
+  /**
+   * Tests the post-update does not create incomplete REST export configuration.
+   */
+  public function testMissingVisibilityFieldIsSkipped(): void {
+    $config = $this->config('views.view.civictheme_alerts');
+    $config->set('display.rest_export_civictheme_alerts.display_options.row.options.field_options', [
+      'rendered_entity' => [
+        'alias' => 'message',
+        'raw_output' => FALSE,
+      ],
+    ])->save();
+
+    $message = civictheme_post_update_alert_visibility_raw_output();
+
+    $this->assertStringContainsString('skipped because the visibility field does not exist', $message);
+    $this->assertNull($this->config('views.view.civictheme_alerts')->get('display.rest_export_civictheme_alerts.display_options.row.options.field_options.field_c_n_alert_page_visibility'));
+  }
+
+  /**
+   * Tests the post-update does not create a missing view configuration.
+   */
+  public function testMissingViewIsSkipped(): void {
+    $message = civictheme_post_update_alert_visibility_raw_output();
+
+    $this->assertStringContainsString('skipped because the visibility field does not exist', $message);
+    $this->assertSame([], \Drupal::service('config.storage')->listAll('views.view.civictheme_alerts'));
+  }
+
+}


### PR DESCRIPTION
Issue: https://www.drupal.org/project/civictheme/issues/3620794

## Checklist before requesting a review

- [x] I have formatted the subject to include the Drupal.org issue number and username.
- [x] I have added a link to the issue tracker.
- [x] I have explained why the change is needed.
- [x] I have performed a self-review of my code.
- [x] I have commented the reason for exporting raw visibility values.
- [x] I have added regression tests.
- [x] I have run new and existing relevant tests locally, and they passed.
- [x] Screenshots are not applicable.

## Changed

Alert visibility rules are data consumed by JavaScript, but the REST export currently sends their rendered field output. The earlier tag-stripping fix handles ordinary multiline paths while leaving HTML entities in values such as `<front>` and `/research&development`. The matcher therefore compares encoded strings with literal paths and fails to match them.

Export only `field_c_n_alert_page_visibility` with `raw_output: true`, retaining rendered message HTML. A guarded, idempotent post-update applies the change to existing configurations without recreating deleted visibility fields. This avoids adding HTML-decoding logic to the browser and preserves the exact stored path rules.

Kernel tests cover applying the update, preserving message rendering, repeat execution, and missing configuration. A separate local REST-renderer comparison against the 1.13.0 matcher passed LF/CRLF lists, wildcards, `<front>`, ampersands, and empty visibility with raw output; the tag-stripping approach failed the front-page and ampersand cases. Empty raw visibility is `false`, which the matcher already treats as unrestricted. The existing unit suite also passes. Full site/Behat suites were not run.

The independent 10-result limit is addressed in https://github.com/civictheme/monorepo-drupal/pull/1544.
